### PR TITLE
Disable uploading supplementary tables on preview

### DIFF
--- a/openprescribing/frontend/management/commands/preview_measure.py
+++ b/openprescribing/frontend/management/commands/preview_measure.py
@@ -9,13 +9,11 @@ from requests.exceptions import InvalidJSONError, RequestException
 from .import_measures import BadRequest
 from .import_measures import Command as ImportMeasuresCommand
 from .import_measures import ImportLog, relativedelta
-from .import_measures import upload_supplementary_tables
 
 
 class Command(BaseCommand):
     def handle(self, github_url, **options):
         try:
-            upload_supplementary_tables()
             measure_id = import_preview_measure(github_url)
         except BadRequest as e:
             # We want these errors to be visble to users who run via bennettbot but the only


### PR DESCRIPTION
This didn't really work as intended because the version of the tables uploaded came from the `main` branch rather than the branch being previewed. But we can't just upload the preview version because it would overwrite the real version (where that already exists). And we can't just upload it under a new name because then the measure SQL would ned rewriting to refer to the new table.

The current workflow is to upload data manually in BQ while previewing and then commit to git once satisfied it's correct.

Slack thread:
https://bennettoxford.slack.com/archives/C051A4P27GE/p1737365651665029