### PR TITLE
Allow "representative" codes to not actually be prescribed

### DIFF
--- a/openprescribing/frontend/price_per_unit/substitution_sets.py
+++ b/openprescribing/frontend/price_per_unit/substitution_sets.py
@@ -112,15 +112,16 @@ def get_substitution_sets():
 
     substitution_sets = []
 
-    for code_group in groups_from_pairs(equivalent_codes):
+    for full_code_group in groups_from_pairs(equivalent_codes):
         # Ignore any codes for which we don't have prescribing data
-        code_group = prescribed_codes.intersection(code_group)
+        code_group = prescribed_codes.intersection(full_code_group)
         if not code_group:
             continue
 
         # Pick a "representative" code whose name we will use as the name for the
-        # substitution set
-        primary_code = get_representative_code(code_group)
+        # substitution set. We need to select this from the full, unfiltered group as
+        # the best name candidate may not actually be a prescribed code.
+        primary_code = get_representative_code(full_code_group)
 
         # Get the unique formulations involved in this substitution set
         formulations_for_group = {


### PR DESCRIPTION
This addresses the problem, identified in Slack below, whereby the generic "Hypromellose 0.3% eye drops preservative free" was being incorrectly described as "Tear-Lac Hypromellose 0.3% eye drops preservative free" because the generic name was being filtered out.

https://bennettoxford.slack.com/archives/C051A4P27GE/p1739210197692999?thread_ts=1738259360.077269&cid=C051A4P27GE