### PR TITLE
Update PPU costs to account for discounts

### DIFF
--- a/openprescribing/frontend/price_per_unit/prescribing_breakdown.py
+++ b/openprescribing/frontend/price_per_unit/prescribing_breakdown.py
@@ -3,6 +3,7 @@ from frontend.models import Presentation
 from matrixstore.db import get_db, get_row_grouper
 from matrixstore.matrix_ops import get_submatrix
 
+from .savings import get_discounts_at_date
 from .substitution_sets import get_substitution_sets
 
 
@@ -33,6 +34,8 @@ def get_prescribing(generic_code, date):
         return {}
     date_slice = slice(date_column, date_column + 1)
 
+    discounts = get_discounts_at_date(bnf_codes, date)
+
     results = db.query(
         """
         SELECT
@@ -49,7 +52,7 @@ def get_prescribing(generic_code, date):
     return {
         bnf_code: (
             get_submatrix(quantity, cols=date_slice),
-            get_submatrix(net_cost, cols=date_slice),
+            get_submatrix(net_cost, cols=date_slice) * discounts[bnf_code],
         )
         for bnf_code, quantity, net_cost in results
     }

--- a/openprescribing/frontend/tests/price_per_unit/test_savings.py
+++ b/openprescribing/frontend/tests/price_per_unit/test_savings.py
@@ -13,6 +13,7 @@ from frontend.price_per_unit.savings import (
     get_total_savings_for_org,
 )
 from frontend.price_per_unit.substitution_sets import get_substitution_sets
+from frontend.tests.utils import round_floats
 from matrixstore.tests.data_factory import DataFactory
 from matrixstore.tests.matrixstore_factory import (
     matrixstore_from_data_factory,
@@ -316,20 +317,3 @@ def get_target_ppu(prescriptions):
 
 def sum_savings(savings):
     return sum([i["possible_savings"] for i in savings])
-
-
-def round_floats(value):
-    """
-    Round all floating point values found anywhere within the supplied data
-    structure, recursing our way through any nested lists, tuples or dicts
-    """
-    if isinstance(value, float):
-        return round(value, 9)
-    elif isinstance(value, list):
-        return [round_floats(i) for i in value]
-    elif isinstance(value, tuple):
-        return tuple(round_floats(i) for i in value)
-    elif isinstance(value, dict):
-        return {k: round_floats(v) for (k, v) in value.items()}
-    else:
-        return value

--- a/openprescribing/frontend/tests/price_per_unit/test_savings.py
+++ b/openprescribing/frontend/tests/price_per_unit/test_savings.py
@@ -6,7 +6,14 @@ from unittest import mock
 import numpy
 from django.core.cache import CacheKeyWarning
 from django.test import TestCase, override_settings
-from frontend.models import PCT, Practice, Presentation
+from dmd.models import (
+    VMP,
+    VMPP,
+    BasisOfName,
+    DtPaymentCategory,
+    VirtualProductPresStatus,
+)
+from frontend.models import PCT, Practice, Presentation, TariffPrice
 from frontend.price_per_unit.savings import (
     CONFIG_MIN_SAVINGS_FOR_ORG_TYPE,
     CONFIG_TARGET_CENTILE,
@@ -14,11 +21,19 @@ from frontend.price_per_unit.savings import (
 )
 from frontend.price_per_unit.substitution_sets import get_substitution_sets
 from frontend.tests.utils import round_floats
+from frontend.views.spending_utils import (
+    BRAND_DISCOUNT_PERCENTAGE,
+    GENERIC_DISCOUNT_PERCENTAGE,
+)
 from matrixstore.tests.data_factory import DataFactory
 from matrixstore.tests.matrixstore_factory import (
     matrixstore_from_data_factory,
     patch_global_matrixstore,
 )
+
+GENERIC_DISCOUNT = (100 - GENERIC_DISCOUNT_PERCENTAGE) / 100.0
+BRAND_DISCOUNT = (100 - BRAND_DISCOUNT_PERCENTAGE) / 100.0
+
 
 # The dummy cache backend we use in testing warns that our binary cache keys
 # won't be compatible with memcached, but we really don't care
@@ -37,10 +52,12 @@ class PricePerUnitSavingsTest(TestCase):
         # Create some sets of substitutable presentations, which each consist
         # of a generic plus some branded equivalents
         substitution_sets = []
+        generic_codes = set()
         for i in range(4):
             generic_code = invent_generic_bnf_code(i)
             brands = invent_brands_from_generic_bnf_code(generic_code)
             substitution_sets.append([generic_code] + brands)
+            generic_codes.add(generic_code)
 
         # Create some practices and some prescribing for these presentations
         factory = DataFactory()
@@ -52,6 +69,10 @@ class PricePerUnitSavingsTest(TestCase):
         factory.create_prescribing(
             factory.presentations, factory.practices, factory.months
         )
+
+        # Flag generic/branded prescribing
+        for rx in factory.prescribing:
+            rx["is_generic"] = rx["bnf_code"] in generic_codes
 
         # The DataFactory creates data that can be written to the MatrixStore
         # but doesn't automatically create anything in the database, so we do
@@ -65,6 +86,37 @@ class PricePerUnitSavingsTest(TestCase):
             Presentation.objects.create(
                 bnf_code=presentation["bnf_code"], name=presentation["name"]
             )
+
+        # We need to create some `TariffPrice` objects so our prescribing has the right
+        # payment category and gets the correct discount applied. Creating a TariffPrice
+        # requires creating a VMPP, which requires creating a VMP so we define a minimal
+        # one here.
+        vmp = VMP.objects.create(
+            id=factory.next_id(),
+            nm="",
+            invalid=False,
+            sug_f="False",
+            glu_f="False",
+            pres_f="False",
+            cfc_f="False",
+            basis=BasisOfName.objects.create(cd=factory.next_id(), descr=""),
+            pres_stat=VirtualProductPresStatus.objects.create(
+                cd=factory.next_id(), descr=""
+            ),
+        )
+        # The `cd` field here is signifiant: it needs to be 1 to represent generics
+        generic_category = DtPaymentCategory.objects.create(cd=1, descr="generic")
+        for bnf_code in generic_codes:
+            vmpp = VMPP.objects.create(
+                id=factory.next_id(), bnf_code=bnf_code, vmp=vmp, nm="", invalid=False
+            )
+            for month in factory.months:
+                TariffPrice.objects.create(
+                    date=month[:10],
+                    vmpp=vmpp,
+                    tariff_category=generic_category,
+                    price_pence=0,
+                )
 
         cls.substitution_sets = substitution_sets
         cls.factory = factory
@@ -231,8 +283,11 @@ def get_savings_for_practice(
         net_cost = 0
         for prescription in filtered_prescriptions:
             if prescription["practice"] == practice["code"]:
+                discount = (
+                    GENERIC_DISCOUNT if prescription["is_generic"] else BRAND_DISCOUNT
+                )
                 quantity += prescription["quantity"]
-                net_cost += prescription["net_cost"]
+                net_cost += prescription["net_cost"] * discount
         target_cost = quantity * target_ppu
         saving = net_cost - target_cost
         if saving >= min_saving:
@@ -270,8 +325,11 @@ def get_savings_for_all_england(date, prescriptions, substitution_sets, min_savi
         quantities = defaultdict(float)
         net_costs = defaultdict(float)
         for prescription in filtered_prescriptions:
+            discount = (
+                GENERIC_DISCOUNT if prescription["is_generic"] else BRAND_DISCOUNT
+            )
             quantities[prescription["practice"]] += prescription["quantity"]
-            net_costs[prescription["practice"]] += prescription["net_cost"]
+            net_costs[prescription["practice"]] += prescription["net_cost"] * discount
         saving = 0
         for k in quantities.keys():
             target_cost = quantities[k] * target_ppu
@@ -304,9 +362,10 @@ def get_target_ppu(prescriptions):
     quantity_by_practice = defaultdict(float)
     cost_by_practice = defaultdict(float)
     for prescription in prescriptions:
+        discount = GENERIC_DISCOUNT if prescription["is_generic"] else BRAND_DISCOUNT
         practice = prescription["practice"]
         quantity_by_practice[practice] += prescription["quantity"]
-        cost_by_practice[practice] += prescription["net_cost"]
+        cost_by_practice[practice] += prescription["net_cost"] * discount
     prices_per_unit = []
     for practice, cost in cost_by_practice.items():
         quantity = quantity_by_practice[practice]

--- a/openprescribing/frontend/tests/test_api_spending.py
+++ b/openprescribing/frontend/tests/test_api_spending.py
@@ -8,6 +8,7 @@ from dmd.models import VMPP
 from frontend.ghost_branded_generics import MIN_GHOST_GENERIC_DELTA
 from frontend.models import Prescription, TariffPrice
 from frontend.tests.data_factory import DataFactory
+from frontend.tests.utils import round_floats
 from matrixstore.tests.decorators import copy_fixtures_to_matrixstore
 
 from .api_test_base import ApiTestBase
@@ -813,7 +814,7 @@ class TestAPISpendingViewsPPUBubble(ApiTestBase):
         # N.B. This is the mean of a *single* value; although there are two
         # values in the raw data one is ignored as it belongs to a
         # non-setting-4 practice
-        self.assertEqual(data["plotline"], 0.0325)
+        self.assertEqual(data["plotline"], 0.030875)
 
     def test_code_without_matches(self):
         url = "/bubble?format=json"
@@ -835,17 +836,17 @@ class TestAPISpendingViewsPPUBubble(ApiTestBase):
             {
                 "series": [
                     {
-                        "y": 0.09,
+                        "y": 0.08,
                         "x": 1,
                         "z": 32,
                         "name": "Chlortalidone 50mg tablets",
-                        "mean_ppu": 0.08875,
+                        "mean_ppu": 0.0843125,
                     }
                 ],
                 "categories": [
                     {"is_generic": True, "name": "Chlortalidone 50mg tablets"}
                 ],
-                "plotline": 0.08875,
+                "plotline": 0.0843125,
             },
         )
 
@@ -856,28 +857,29 @@ class TestAPISpendingViewsPPUBubble(ApiTestBase):
         url = self.api_prefix + url
         response = self.client.get(url, follow=True)
         data = _parse_json_response(response)
+        data = round_floats(data)
         self.assertEqual(
             data,
             {
                 "series": [
                     {
-                        "y": 0.09,
                         "x": 1,
-                        "z": 32,
+                        "y": 0.08,
+                        "z": 32.0,
                         "name": "Chlortalidone 50mg tablets",
-                        "mean_ppu": 0.098,
+                        "mean_ppu": 0.0931,
                     },
                     {
-                        "y": 0.1,
                         "x": 1,
-                        "z": 128,
+                        "y": 0.1,
+                        "z": 128.0,
                         "name": "Chlortalidone 50mg tablets",
-                        "mean_ppu": 0.098,
+                        "mean_ppu": 0.0931,
                     },
                 ],
                 "categories": [
                     {"is_generic": True, "name": "Chlortalidone 50mg tablets"}
                 ],
-                "plotline": 0.08875,
+                "plotline": 0.0843125,
             },
         )

--- a/openprescribing/frontend/tests/test_spending_views.py
+++ b/openprescribing/frontend/tests/test_spending_views.py
@@ -13,6 +13,7 @@ from frontend.models import (
     TariffPrice,
 )
 from frontend.tests.data_factory import DataFactory
+from frontend.tests.utils import round_floats
 from frontend.views.spending_utils import (
     APPLIANCE_DISCOUNT_PERCENTAGE,
     BRAND_DISCOUNT_PERCENTAGE,
@@ -93,13 +94,13 @@ class TestSpendingViews(TestCase):
         with self.subTest(function="_ncso_spending_for_entity"):
             results = ncso_spending_for_entity(*args, **kwargs)
             expected = recalculate_ncso_spending_for_entity(*args, **kwargs)
-            self.assertEqual(round_floats(results), round_floats(expected))
+            self.assertEqual(round_floats(results, 2), round_floats(expected, 2))
 
     def validate_ncso_spending_breakdown_for_entity(self, *args, **kwargs):
         with self.subTest(function="_ncso_spending_breakdown_for_entity"):
             results = ncso_spending_breakdown_for_entity(*args, **kwargs)
             expected = recalculate_ncso_spending_breakdown_for_entity(*args, **kwargs)
-            self.assertEqual(round_floats(results), round_floats(expected))
+            self.assertEqual(round_floats(results, 2), round_floats(expected, 2))
 
     def test_spending_views(self):
         # Basic smoketest which just checks that the view loads OK and has
@@ -167,19 +168,6 @@ class TestSpendingViews(TestCase):
         url = "/national/england/concessions/"
         response = self.client.get(url)
         self.assertContains(response, "Get email updates")
-
-
-def round_floats(value):
-    if isinstance(value, float):
-        return round(value, 2)
-    elif isinstance(value, list):
-        return [round_floats(i) for i in value]
-    elif isinstance(value, tuple):
-        return tuple(round_floats(i) for i in value)
-    elif isinstance(value, dict):
-        return {k: round_floats(v) for (k, v) in value.items()}
-    else:
-        return value
 
 
 ##############################################################################

--- a/openprescribing/frontend/tests/utils.py
+++ b/openprescribing/frontend/tests/utils.py
@@ -1,0 +1,15 @@
+def round_floats(value, precision=9):
+    """
+    Round all floating point values found anywhere within the supplied data
+    structure, recursing our way through any nested lists, tuples or dicts
+    """
+    if isinstance(value, float):
+        return round(value, precision)
+    elif isinstance(value, list):
+        return [round_floats(i, precision) for i in value]
+    elif isinstance(value, tuple):
+        return tuple(round_floats(i, precision) for i in value)
+    elif isinstance(value, dict):
+        return {k: round_floats(v, precision) for (k, v) in value.items()}
+    else:
+        return value

--- a/openprescribing/matrixstore/tests/test_row_grouper.py
+++ b/openprescribing/matrixstore/tests/test_row_grouper.py
@@ -3,6 +3,7 @@ from itertools import product
 
 import numpy
 from django.test import SimpleTestCase
+from frontend.tests.utils import round_floats
 from matrixstore.matrix_ops import finalise_matrix, sparse_matrix
 from matrixstore.row_grouper import RowGrouper
 
@@ -280,20 +281,3 @@ def to_list_of_lists(matrix):
     return [
         [matrix[i, j] for j in range(matrix.shape[1])] for i in range(matrix.shape[0])
     ]
-
-
-def round_floats(value):
-    """
-    Round all floating point values found anywhere within the supplied data
-    structure, recursing our way through any nested lists, tuples or dicts
-    """
-    if isinstance(value, float):
-        return round(value, 9)
-    elif isinstance(value, list):
-        return [round_floats(i) for i in value]
-    elif isinstance(value, tuple):
-        return tuple(round_floats(i) for i in value)
-    elif isinstance(value, dict):
-        return {k: round_floats(v) for (k, v) in value.items()}
-    else:
-        return value

--- a/openprescribing/templates/price_per_unit.html
+++ b/openprescribing/templates/price_per_unit.html
@@ -143,7 +143,7 @@
 
 <h2>Interpretation</h2>
 
-<p>In general, if pill <strong>A1</strong> is expensive and pill <strong>A2</strong> is cheap, the savings could be achieved by switching to prescribing as much as possible of pill <strong>A2</strong>. We don't explictly identify <strong>A2</strong> on your behalf, because there may be many reasons (see our <a href="/price-per-unit-faq">FAQ</a> why particular switches are not clinically appropriate or are impractical.</p>
+<p>In general, if pill <strong>A1</strong> is expensive and pill <strong>A2</strong> is cheap, the savings could be achieved by switching to prescribing as much as possible of pill <strong>A2</strong>. We don't explictly identify <strong>A2</strong> on your behalf, because there may be many reasons (see our <a href="/price-per-unit-faq">FAQ</a>) why particular switches are not clinically appropriate or are impractical.</p>
 <p>We do, however, provide charts for each presentation which show the distribution of different PPUs for all brands that have been prescribed in a given month. This can help identify brands (or generics) to which it might make sense to switch.  Click the presentation name to drill down and view this data.</p>
 <p>Read <a href="/price-per-unit-faq">Frequently Asked Questions</a> here.</p>
 


### PR DESCRIPTION
This updates the PPU calculation so that when we aggregate the prices paid for a given presentation we apply the appropriate discount, as determined by the tariff category of that presentation. We also take into account whether there was a price concession for the presentation in that month because, if so, no discount is applicable.

This borrows from logic already implemented in:
 * https://github.com/bennettoxford/openprescribing/pull/4869