### PR TITLE
Update ncso import command to handle new rolled over concessions table

### DIFF
--- a/openprescribing/pipeline/management/commands/fetch_and_import_ncso_concessions.py
+++ b/openprescribing/pipeline/management/commands/fetch_and_import_ncso_concessions.py
@@ -30,19 +30,35 @@ DEFAULT_HEADERS = {
     "User-Agent": "OpenPrescribing-Bot (+https://openprescribing.net)",
 }
 
-
-HEADING_DATE_RE = re.compile(
-    r"""
-    ^
-    # Optional leading text
-    ( The \s+ following \s+ price \s+ concessions \s+ have \s+ been \s+ granted \s+ for \s+ )?
-    # Date in the form "March 2020"
+DATE_RE = r"""
     (?P<month>
         january | february | march | april | may | june | july | august |
         september | october | november | december
     )
     \s+
     (?P<year> 20\d\d)
+"""
+
+HEADING_DATE_RE = re.compile(
+    rf"""
+    ^
+    # Optional leading text
+    ( The \s+ following \s+ price \s+ concessions \s+ have \s+ been \s+ granted \s+ for \s+ )?
+    # Date in the form "March 2020"
+    {DATE_RE}
+    $
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+ROLLED_OVER_HEADING_DATE_RE = re.compile(
+    rf"""
+    ^
+    # Optional leading text
+    ( The \s+ following \s+ price \s+ concessions \s+ rolled \s+ over \s+ from \s+ \w+ \s+ 20\d\d \s+ to \s+ )?
+    # Date in the form "March 2020"
+    {DATE_RE}
+    :?
     $
     """,
     re.VERBOSE | re.IGNORECASE,
@@ -102,7 +118,9 @@ def parse_concessions(html):
         for row in rows:
             yield {
                 "date": date,
-                "drug": row[0],
+                # Strip trailing asterisks which are sometimes used to indicate rolled over
+                # concessions
+                "drug": row[0].strip("*"),
                 "pack_size": row[1],
                 "price_pence": parse_price(row[2]),
             }
@@ -115,9 +133,18 @@ def get_date_for_table(table):
         return parse_date(f"1 {match['month']} {match['year']}")
     # However later sections of the historical archive are grouped by year, and in this
     # case the date for the table is given by the text immediately preceeding it
-    elif re.match(r"\d\d\d\d", heading):
+    #
+    # Rolled over price concessions may also appear as their own table, again the
+    # date for the table is given by the text immediately preceding it
+    # The rolled over concessions, when seen in a separate table, ALSO appear
+    # in the main table for that month; we could ignore the rolled-over table, but in
+    # case they are separated out in future, we parse data from both tables and check
+    # for duplicates in match_concession_vmpp_ids() later
+    elif re.match(r"[\d\d\d\d]|[Rolled over price concessions]", heading):
         intro = fix_spaces(table.find_previous_sibling().text or "")
-        if match := HEADING_DATE_RE.match(intro):
+        if match := HEADING_DATE_RE.match(intro) or ROLLED_OVER_HEADING_DATE_RE.match(
+            intro
+        ):
             return parse_date(f"1 {match['month']} {match['year']}")
         else:
             assert False, f"Unhandled table intro: {intro!r}"
@@ -210,8 +237,8 @@ def match_concession_vmpp_ids(items, vmpp_id_to_name):
             item["vmpp_id"] = get_vmpp_id_from_previous_concession(
                 item["drug"], item["pack_size"]
             )
-
-        matched.append(item)
+        if item not in matched:
+            matched.append(item)
 
     return matched
 

--- a/openprescribing/pipeline/test-data/pages/price_concessions.html
+++ b/openprescribing/pipeline/test-data/pages/price_concessions.html
@@ -1034,7 +1034,7 @@ When community pharmacies cannot source a drug at or below the reimbursement pri
 <td width="116">Price concession</td>
 </tr>
 <tr>
-<td>Amiloride 5mg tablets</td>
+<td>Amiloride 5mg tablets*</td>
 <td>28</td>
 <td>£15.54</td>
 </tr>
@@ -1268,6 +1268,24 @@ When community pharmacies cannot source a drug at or below the reimbursement pri
 <p>No additional endorsements are required for price concessions. <strong>A price concession only applies for the month it is granted; any prices agreed for concessions requested late in the month will roll over into the following month, </strong><strong>unless Community Pharmacy England requested it late in the month and it has been agreed the price will roll over into the following month. Rolled over prices will be identified as such.</strong></p>
 <p style="text-align: justify;">We encourage pharmacies to report any problems obtaining a Part VIII product at or below the stated Drug Tariff price, using the <u><a href="https://cpe.org.uk/dispensing-and-supply/supply-chain/problems-with-obtaining-a-generic-medicine/" data-auth="NotApplicable" data-linkindex="0" data-safelink="true"><strong>online feedback form</strong></a></u> on the our website. Please include full details of the supplier and price paid for any products sourced above the Drug Tariff price. We will investigate the extent of the problem and, if appropriate, discuss the issue with DHSC. We are still working with the DHSC to agree concessionary prices for other drugs reported to be unavailable at the stated November 2023 Drug Tariff price. Please note that we cannot provide details of any generic products awaiting price concession approval from DHSC.</p>
 <p style="text-align: justify;"><em>Contractors will be alerted to further updates to the price concession list through our website and via our e-news email.  If you wish to <a href="https://cpe.org.uk/signup/">subscribe to our email list</a>, you can receive an email as soon as any announcements are made. </em></p>
+<p style="text-align: justify;"></div></p>
+<p><strong><div class="trigger the-trigger">Rolled over price concessions<div class="icon"></div></div><div class="toggle_container"></strong></p>
+<p><strong>The following price concessions rolled over from December 2023 to January 2024:</strong></p>
+<table style="width: 503px;" width="513">
+<tbody>
+<tr>
+<td style="width: 357px;" width="385"><strong>Drug</strong></td>
+<td style="width: 65px;" width="64"><strong>Pack size</strong></td>
+<td style="width: 81px;" width="64"><strong>Price concession</strong></td>
+</tr>
+<tr>
+<td>Amiloride 5mg tablets</td>
+<td>28</td>
+<td>£15.54</td>
+</tr>
+</tbody>
+</table>
+<p style="text-align: justify;">Any rolled over prices can be adjusted upwards if we receive reports from our pharmacies to indicate that suppliers’ selling prices have increased. The review can be requested at any point during the month.</p>
 <p style="text-align: justify;"></div></p>
 <hr />
 <h3>Background</h3>


### PR DESCRIPTION
In previous months, rolled over concessions have been in the monthly concession table, either with an * or in a different colour. This month, they are still in the Feb concession table, but there is an additional section and table for "Rolled over concessions" which shows just the rolled over ones. This has caused the [import to error](https://bennettoxford.slack.com/archives/CGF9TKZLG/p1739791386365429).

I considered just skipping this table, but I'm concerned that future reports might separate out the rolled-over concessions so we'd miss them by parsing only the current month's table. So I've made it handle both tables, and filter out duplicate VMPP matches.