### PR TITLE
Replace pysqlite3-binary with sqlean.py

### DIFF
--- a/openprescribing/openprescribing/settings/base.py
+++ b/openprescribing/openprescribing/settings/base.py
@@ -13,8 +13,8 @@ from django.core.exceptions import ImproperlyConfigured
 # this is an experiment for now this is a quick and non-invasive way of trying
 # it out. Longer term we can change our own code to import pysqlite3 directly
 # and do some more targetted monkey patching for DiskCache.
-__import__("pysqlite3")
-sys.modules["sqlite3"] = sys.modules.pop("pysqlite3")
+__import__("sqlean")
+sys.modules["sqlite3"] = sys.modules.pop("sqlean")
 
 # PATH CONFIGURATION
 # Absolute filesystem path to the Django project directory:

--- a/requirements.in
+++ b/requirements.in
@@ -36,13 +36,13 @@ pandas-gbq
 pandas
 premailer
 psycopg2-binary
-pysqlite3-binary
 python-dateutil
 pytz
 raven
 requests-futures
 requests[security]
 scipy
+sqlean.py
 # Changes to the capitalisation rules in later versions break our tests
 titlecase==0.12.0
 xlrd

--- a/requirements.txt
+++ b/requirements.txt
@@ -281,8 +281,6 @@ pyquery==2.0.1
     # via -r requirements.in
 pysocks==1.7.1
     # via urllib3
-pysqlite3-binary==0.5.4
-    # via -r requirements.in
 python-dateutil==2.9.0.post0
     # via
     #   -r requirements.in
@@ -330,6 +328,8 @@ sortedcontainers==2.4.0
     # via trio
 soupsieve==2.6
     # via beautifulsoup4
+sqlean-py==3.47.0
+    # via -r requirements.in
 sqlparse==0.5.3
     # via
     #   django


### PR DESCRIPTION
Is similar to, and has the same rationale as [what is done in this commit](https://github.com/opensafely-core/opencodelists/commit/9fc9a592329837f103b5b3d3562cf01119f63f6f).

Prompted by @inglesp helping me set up the repo locally on a Mac.