### PR TITLE
Partially revert handling of rolled over concessions

### DIFF
--- a/openprescribing/pipeline/tests/test_fetch_and_import_ncso_concessions.py
+++ b/openprescribing/pipeline/tests/test_fetch_and_import_ncso_concessions.py
@@ -19,14 +19,9 @@ class TestFetchAndImportNCSOConcesions(TestCase):
         base_path = Path(settings.APPS_ROOT) / "pipeline/test-data/pages"
         page_content = (base_path / "price_concessions.html").read_text()
         items = list(fetch_ncso.parse_concessions(page_content))
-
-        self.assertEqual(len(items), 47)
-        # Amiloride is a rolled-over concession that appears with an asterisk
-        # in the main concessions table and again in the rolled over table
-        # It is parsed twice but duplicate matches are ignored later
-        self.assertEqual(items[0], items[-1])
+        self.assertEqual(len(items), 46)
         self.assertEqual(
-            items[:3] + items[-4:],
+            items[:3] + items[-3:],
             [
                 {
                     "date": datetime.date(2024, 1, 1),
@@ -63,12 +58,6 @@ class TestFetchAndImportNCSOConcesions(TestCase):
                     "drug": "Zopiclone 7.5mg tablets",
                     "pack_size": "28",
                     "price_pence": 156,
-                },
-                {
-                    "date": datetime.date(2024, 1, 1),
-                    "drug": "Amiloride 5mg tablets",
-                    "pack_size": "28",
-                    "price_pence": 1554,
                 },
             ],
         )
@@ -136,27 +125,6 @@ class TestFetchAndImportNCSOConcesions(TestCase):
         }
         self.assertEqual(
             fetch_ncso.match_concession_vmpp_ids([concession], vmpp_id_to_name),
-            [expected],
-        )
-
-    def test_match_concession_vmpp_ids_duplicates(self):
-        # A duplicate VMPP match is only returned once
-        concession = {
-            "drug": "Amiloride 5mg tablets",
-            "pack_size": "28",
-        }
-        vmpp_id_to_name = {
-            1191111000001100: "Amiloride 5mg tablets 28 tablet",
-        }
-        expected = {
-            "drug": "Amiloride 5mg tablets",
-            "pack_size": "28",
-            "vmpp_id": 1191111000001100,
-        }
-        self.assertEqual(
-            fetch_ncso.match_concession_vmpp_ids(
-                [concession, concession], vmpp_id_to_name
-            ),
             [expected],
         )
 


### PR DESCRIPTION
We still want to gracefully handle the presence of rolled over concession tables, but we want to ignore them rather than parse them. We don't need to include them because they will show up in the standard concession tables later. And if do include them then whenever we ingest the final concessions for, say, March we end up also ingesting the rolled over concessions for April. Then, because we have concessions recorded for April, when we send email alerts we send them for April rather than March.

It would be possible to change the behaviour of the email alert system here, but we would need someway to distinguish newly announced concessions from rolled over concessions which would be more work. Just ignoring the rolled over tables is simpler.

This partially reverts commit 471495d4702f8653d54b4daa0e07473e6b5ae224.

See Slack discussion at:
https://bennettoxford.slack.com/archives/C051A4P27GE/p1741359107797689?thread_ts=1741275443.274869&cid=C051A4P27GE