### PR TITLE
Remove reliance on "fake" presentations in PPU code

### DIFF
--- a/openprescribing/frontend/price_per_unit/substitution_sets.py
+++ b/openprescribing/frontend/price_per_unit/substitution_sets.py
@@ -161,6 +161,7 @@ def get_substitution_sets_by_presentation():
     """
     index = {}
     for substitution_set in get_substitution_sets().values():
+        index[substitution_set.id] = substitution_set
         for presentation in substitution_set.presentations:
             index[presentation] = substitution_set
     return index

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -915,7 +915,6 @@ def price_per_unit_by_presentation(request, entity_code, bnf_code):
         "highlight_name": entity.cased_name,
         "name": presentation.product_name,
         "bnf_code": presentation.bnf_code,
-        "presentation": presentation,
         "dmd_info": presentation.dmd_info(),
         "date": date,
         "by_presentation": True,
@@ -944,7 +943,6 @@ def all_england_price_per_unit_by_presentation(request, bnf_code):
     context = {
         "name": presentation.product_name,
         "bnf_code": presentation.bnf_code,
-        "presentation": presentation,
         "dmd_info": presentation.dmd_info(),
         "date": date,
         "by_presentation": True,

--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -888,8 +888,7 @@ def all_england_price_per_unit(request):
 @handle_bad_request
 def price_per_unit_by_presentation(request, entity_code, bnf_code):
     date = _specified_or_last_date(request, "prescribing")
-    presentation = get_object_or_404(Presentation, pk=bnf_code)
-    primary_code = _get_primary_substitutable_bnf_code(bnf_code)
+    primary_code, product_name, dmd_info = _get_substitution_details(bnf_code)
     if bnf_code != primary_code:
         url = request.get_full_path().replace(bnf_code, primary_code)
         return HttpResponseRedirect(url)
@@ -900,7 +899,7 @@ def price_per_unit_by_presentation(request, entity_code, bnf_code):
 
     params = {
         "format": "json",
-        "bnf_code": presentation.bnf_code,
+        "bnf_code": bnf_code,
         "highlight": entity.code,
         "date": date.strftime("%Y-%m-%d"),
     }
@@ -913,9 +912,9 @@ def price_per_unit_by_presentation(request, entity_code, bnf_code):
         "entity_name_and_status": entity.name_and_status,
         "highlight": entity.code,
         "highlight_name": entity.cased_name,
-        "name": presentation.product_name,
-        "bnf_code": presentation.bnf_code,
-        "dmd_info": presentation.dmd_info(),
+        "name": product_name,
+        "bnf_code": bnf_code,
+        "dmd_info": dmd_info,
         "date": date,
         "by_presentation": True,
         "bubble_data_url": bubble_data_url,
@@ -926,24 +925,23 @@ def price_per_unit_by_presentation(request, entity_code, bnf_code):
 @handle_bad_request
 def all_england_price_per_unit_by_presentation(request, bnf_code):
     date = _specified_or_last_date(request, "prescribing")
-    presentation = get_object_or_404(Presentation, pk=bnf_code)
-    primary_code = _get_primary_substitutable_bnf_code(bnf_code)
+    primary_code, product_name, dmd_info = _get_substitution_details(bnf_code)
     if bnf_code != primary_code:
         url = request.get_full_path().replace(bnf_code, primary_code)
         return HttpResponseRedirect(url)
 
     params = {
         "format": "json",
-        "bnf_code": presentation.bnf_code,
+        "bnf_code": bnf_code,
         "date": date.strftime("%Y-%m-%d"),
     }
 
     bubble_data_url = _build_api_url("bubble", params)
 
     context = {
-        "name": presentation.product_name,
-        "bnf_code": presentation.bnf_code,
-        "dmd_info": presentation.dmd_info(),
+        "name": product_name,
+        "bnf_code": bnf_code,
+        "dmd_info": dmd_info,
         "date": date,
         "by_presentation": True,
         "bubble_data_url": bubble_data_url,
@@ -954,7 +952,7 @@ def all_england_price_per_unit_by_presentation(request, bnf_code):
     return render(request, "price_per_unit.html", context)
 
 
-def _get_primary_substitutable_bnf_code(bnf_code):
+def _get_substitution_details(bnf_code):
     """
     If this BNF code belongs to a "substitution set" (e.g. it's a branded
     version of a generic presentation) then return the primary code of that
@@ -962,9 +960,24 @@ def _get_primary_substitutable_bnf_code(bnf_code):
     """
     substitution_sets = get_substitution_sets_by_presentation()
     try:
-        return substitution_sets[bnf_code].id
+        substitution = substitution_sets[bnf_code]
     except KeyError:
-        return bnf_code
+        substitution = None
+
+    presentation = Presentation.objects.filter(pk=bnf_code).first()
+
+    if substitution is not None:
+        new_bnf_code = substitution.id
+        name = substitution.name
+        dmd_info = presentation.dmd_info() if presentation else None
+    elif presentation is not None:
+        new_bnf_code = bnf_code
+        name = presentation.product_name
+        dmd_info = presentation.dmd_info()
+    else:
+        raise Http404()
+
+    return new_bnf_code, name, dmd_info
 
 
 ##################################################

--- a/openprescribing/templates/price_per_unit.html
+++ b/openprescribing/templates/price_per_unit.html
@@ -69,7 +69,7 @@
     </div>
     <p>
       We have identified about <strong>£<span id="total-savings"><span class="text-muted">(&hellip;)</span></span> of possible savings</strong>
-      {% if presentation %} for {{ presentation.product_name }}{% endif %} in
+      {% if by_presentation %} for {{ name }}{% endif %} in
       {% if entity.ccg %}
         <a href="{% url 'practice_price_per_unit' highlight %}?date={{ date|date:"Y-m-d" }}">{{entity_name }}</a>
       {% elif entity %}
@@ -86,11 +86,11 @@
       {% endif %}
     </p>
     {% if by_presentation %}
-      <h3>What is the cheapest presentation of {{ presentation.product_name }}?</h3>
+      <h3>What is the cheapest presentation of {{ name }}?</h3>
       <p>
         The following chart is to help you pick the cheapest treatment. It shows
         the various prices for all brands and formulations of
-        <span id="extended-info-link">{{ presentation.product_name }}</span> that are
+        <span id="extended-info-link">{{ name }}</span> that are
         prescribed across the country.
         {% if entity %}
           You can click the adjacent tab to view your own practice or Sub-ICB Location’s prescribing.


### PR DESCRIPTION
In order to make the PPU code work for blood/urine testing reagents we previously relied on adding some made up presentations to our presentations table:
```
0601060D0AAA0A0 - Glucose Blood Testing Reagents
0601060U0AAA0A0 - Urine Testing Reagents
```

However this was always a bit of a hack, and it [doesn't work properly](https://bennettoxford.slack.com/archives/C051A4P27GE/p1742226280745389?thread_ts=1742209961.987009&cid=C051A4P27GE) when we try to update the new PPU SQL to handle blood glucose strips:
 * https://github.com/bennettoxford/openprescribing/pull/5159

This applies the proper fix we discussed in July 2020.

Closes #2738