### PR TITLE
Attempt to improve performance of PPU pages

### DIFF
--- a/openprescribing/frontend/price_per_unit/substitution_sets.py
+++ b/openprescribing/frontend/price_per_unit/substitution_sets.py
@@ -10,6 +10,7 @@ fetch a string giving the formulation of each presentation.
 
 import functools
 import hashlib
+import time
 from pathlib import Path
 
 from django.db import connection
@@ -68,7 +69,7 @@ def cache_until_dmd_import(fn):
     Cache the results of `fn` until the next dm+d import
     """
 
-    cache = {"key": None}
+    cache = {"key": None, "time": 0.0}
 
     @functools.wraps(fn)
     def wrapper():
@@ -76,12 +77,22 @@ def cache_until_dmd_import(fn):
         # is fast to check and, as far as I can tell, pretty much guaranteed to change
         # when we import new data. I'd rather check this than be forced to rely on the
         # ImportLog table.
+
+        # Although the check is fast in relative terms it still involves a db roundtrip
+        # and we sometimes end up calling this is rapid succession so we only check the
+        # db once a minute.
+        now = time.monotonic()
+        if cache["key"] is not None and (now - cache["time"]) < 60:
+            return cache["value"]
+
         new_key = PriceInfo.objects.aggregate(Max("id", default=0))
         if cache["key"] == new_key:
+            cache["time"] = now
             return cache["value"]
         else:
             cache["value"] = fn()
             cache["key"] = new_key
+            cache["time"] = now
             return cache["value"]
 
     # Provide the same API as the old `@memoize` decorator so tests can use it


### PR DESCRIPTION
This is less about making things snappy and more about making them work at all: we'd reached a point where cold-cache requests were taking so long they were hitting the Cloudflare timeout and being killed and thus never getting the opportunity to populate the cache. So we were stuck in a doom loop of constantly trying and failing to populate the cache and the PPU pages were effectively down.

I've tested locally using the full production data and the changes here seem to make enough of a difference to be worth doing. I am however regretting the very clever and complicated caching system which past-me seemed to think was a good idea at the time.

Related Slack thread:
https://bennettoxford.slack.com/archives/C051A4P27GE/p1750333002984549