### PR TITLE
Add History variable.json

### DIFF
--- a/openprescribing/frontend/views/views.py
+++ b/openprescribing/frontend/views/views.py
@@ -528,11 +528,15 @@ def _get_measure_details(measure_id):
         return {}
     with open(file, "r") as f:
         details = json.load(f)
-    formatted_details = {
-        key: value if not isinstance(value, list) else "\n".join(value)
-        for key, value in details.items()
-    }
-    return formatted_details
+    for key, value in details.items():
+        if isinstance(value, list):
+            # We approximate support for multi-line strings by allowing strings
+            # to be split into a list of shorter strings.
+            if key == "history":
+                # history is a list of dicts not strings, so we ignore it here.
+                continue
+            details[key] = "\n".join(value)
+    return details
 
 
 def measure_for_one_entity(request, measure, entity_code, entity_type):

--- a/openprescribing/measures/definitions/saba.json
+++ b/openprescribing/measures/definitions/saba.json
@@ -58,11 +58,32 @@
     "AND \n",
     "count.ing_count <3 --only includes inhalers with fewer than 3 ingredients, removing triple therapy (usually used in COPD)"
   ],
+
   "authored_by": "richard.croker@phc.ox.ac.uk",
   "checked_by": "christopher.wood@phc.ox.ac.uk",
   "date_reviewed": "2024-12-02",
   "next_review": "2025-12-02",
   "measure_complexity": "medium",
   "measure_type": "dmd",
-  "radar_exclude": false
+  "radar_exclude": false,
+  "history": [
+    {
+      "date": "2016-12-09",
+      "description": "Created measure",
+      "action_by": "richard.croker@phc.ox.ac.uk",
+      "checked_by": "sebastian.bacon@phc.ox.ac.uk"
+    },
+    {
+      "date": "2024-12-02",
+      "description": "Reviewed measure - code logic tidied, text and links updated",
+      "action_by": "richard.croker@phc.ox.ac.uk",
+      "checked_by": "christopher.wood@phc.ox.ac.uk"
+    },
+    {
+      "date": "2025-09-02",
+      "description": "Adjust quantities where inhaler count is shown instead of dose count. Remove triple inhalers from corticosteroids in denominator.",
+      "action_by": "richard.croker@phc.ox.ac.uk",
+      "checked_by": "andrew.brown@phc.ox.ac.uk"
+    }
+  ]
 }


### PR DESCRIPTION
Added history variable, populated with summary of key events.

Existing 'checked_by' and 'authored_by' fields retained in code for now, but these can likely be removed once we have successfully linked the history variable to display on website.