### PR TITLE
Remove SeleniumTestCase.host

### DIFF
--- a/openprescribing/frontend/tests/functional/selenium_base.py
+++ b/openprescribing/frontend/tests/functional/selenium_base.py
@@ -33,7 +33,6 @@ def use_browserstack():
     "nonfunctional tests specified in TEST_SUITE environment variable",
 )
 class SeleniumTestCase(StaticLiveServerTestCase):
-    host = "0.0.0.0"
     display = None
 
     @classmethod


### PR DESCRIPTION
SeleniumTestCase.host set the server's bind address to 0.0.0.0, or "listen on every network interface". However, SeleniumTestCase.host is used by SeleniumTestCase.live_server_url to construct URLs. Whilst most OSs reject attempts to connect to 0.0.0.0, some treat 0.0.0.0 as equivalent to 127.0.0.1 (localhost). Consequently, tests that called SeleniumTestCase.live_server_url would pass or fail, depending on the OS.

Rather than reasoning about why these tests pass or fail, it's easier to remove SeleniumTestCase.host, and default to LiveServerTestCase.host, which is is set to localhost.