### PR TITLE
Expunge Coveralls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,6 @@ services:
       - DJANGO_SETTINGS_MODULE=openprescribing.settings.test
       - BROWSER=${BROWSER}
       - TEST_SUITE=${TEST_SUITE}
-      - COVERALLS_REPO_TOKEN=${COVERALLS_REPO_TOKEN}
-      - COVERALLS_PARALLEL=true
       - GOOGLE_APPLICATION_CREDENTIALS=/code/google-credentials.json
       - GITHUB_ACTIONS=${GITHUB_ACTIONS}
       - BROWSERSTACK_USERNAME=${BROWSERSTACK_USERNAME}
@@ -46,8 +44,6 @@ services:
     environment:
       - TEST_SUITE=${TEST_SUITE}
       - BROWSER=${BROWSER}
-      - COVERALLS_REPO_TOKEN=${COVERALLS_REPO_TOKEN}
-      - COVERALLS_PARALLEL=true
       - GOOGLE_APPLICATION_CREDENTIALS=/code/google-credentials.json
     extra_hosts:
       - "saucehost:${SAUCE_HOST-127.0.0.1}"


### PR DESCRIPTION
As with Travis (0320ca5), we no longer use Coveralls, so it's just a
little bit confusing and just a little bit untidy to have
Coveralls-related environment variables in the codebase. More
importantly, because the Coveralls-related environment variables are
referenced by docker-compose.yml, a call to `docker compose` for any
service will emit a warning for each missing environment variable. These
warnings can obscure more important information and can lead to warning
fatigue.
