### PR TITLE
Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,10 @@ services:
 
   db-test:
     image: postgis/postgis:16-3.4
-    env_file: environment-docker
+    environment:
+      - POSTGRES_PASSWORD=pass
+      - POSTGRES_USER=user
+      - POSTGRES_DB=openprescribing-test
     ports:
       - "5432:5432"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data/
+      - postgis_data:/var/lib/postgresql/data/
     healthcheck:
       test: [ "CMD-SHELL", "pg_isready; exit $(( $? != 0 ))" ]
       interval: 30s
@@ -66,4 +66,4 @@ services:
       - postgis
 
 volumes:
-  postgres_data:
+  postgis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,10 +54,6 @@ services:
     depends_on:
       - db-test
 
-  db-dev:
-    image: postgis/postgis:16-3.4
-    env_file: environment-docker
-
   dev:
     image: ghcr.io/bennettoxford/openprescribing-py312-test:latest
     command: /bin/bash -c './scripts/docker_setup.sh local &&  cd openprescribing && /bin/bash -l'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 services:
+
   db-test:
     image: postgis/postgis:16-3.4
     env_file: environment-docker
@@ -13,6 +14,7 @@ services:
       retries: 3
       start_period: 30s
       start_interval: 5s
+
   test:
     image: ghcr.io/bennettoxford/openprescribing-py312-test:latest
     command: /bin/bash -c './scripts/docker_setup.sh test && cd openprescribing && make test'
@@ -55,6 +57,7 @@ services:
   db-dev:
     image: postgis/postgis:16-3.4
     env_file: environment-docker
+
   dev:
     image: ghcr.io/bennettoxford/openprescribing-py312-test:latest
     command: /bin/bash -c './scripts/docker_setup.sh local &&  cd openprescribing && /bin/bash -l'
@@ -65,5 +68,6 @@ services:
       - .:/code
     depends_on:
       - db-dev
+
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
 
-  db-test:
+  postgis:
     image: postgis/postgis:16-3.4
     environment:
       - POSTGRES_PASSWORD=pass
@@ -38,7 +38,7 @@ services:
     volumes:
       - .:/code
     depends_on:
-      - db-test
+      - postgis
 
   test-production:
     image: ghcr.io/bennettoxford/openprescribing-py312-base:latest
@@ -53,7 +53,7 @@ services:
     volumes:
       - .:/code
     depends_on:
-      - db-test
+      - postgis
 
   dev:
     image: ghcr.io/bennettoxford/openprescribing-py312-test:latest
@@ -63,7 +63,7 @@ services:
     volumes:
       - .:/code
     depends_on:
-      - db-test
+      - postgis
 
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   test:
     image: ghcr.io/bennettoxford/openprescribing-py312-test:latest
-    command: /bin/bash -c './scripts/docker_setup.sh test && cd openprescribing && make test'
+    command: /bin/bash -c './scripts/docker_setup.sh && cd openprescribing && make test'
     environment:
       - DJANGO_SETTINGS_MODULE=openprescribing.settings.test
       - BROWSER=${BROWSER}
@@ -42,7 +42,7 @@ services:
 
   test-production:
     image: ghcr.io/bennettoxford/openprescribing-py312-base:latest
-    command: /bin/bash -c './scripts/docker_setup.sh production && cd openprescribing && python manage.py check --deploy --settings openprescribing.settings.production'
+    command: /bin/bash -c './scripts/docker_setup.sh && cd openprescribing && python manage.py check --deploy --settings openprescribing.settings.production'
     environment:
       - TEST_SUITE=${TEST_SUITE}
       - BROWSER=${BROWSER}
@@ -57,7 +57,7 @@ services:
 
   dev:
     image: ghcr.io/bennettoxford/openprescribing-py312-test:latest
-    command: /bin/bash -c './scripts/docker_setup.sh local &&  cd openprescribing && /bin/bash -l'
+    command: /bin/bash -c './scripts/docker_setup.sh &&  cd openprescribing && /bin/bash -l'
     ports:
       - "8000:8000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,8 +42,9 @@ services:
 
   test-production:
     image: ghcr.io/bennettoxford/openprescribing-py312-base:latest
-    command: /bin/bash -c './scripts/docker_setup.sh && cd openprescribing && python manage.py check --deploy --settings openprescribing.settings.production'
+    command: /bin/bash -c './scripts/docker_setup.sh && cd openprescribing && python manage.py check --deploy'
     environment:
+      - DJANGO_SETTINGS_MODULE=openprescribing.settings.production
       - TEST_SUITE=${TEST_SUITE}
       - BROWSER=${BROWSER}
       - GOOGLE_APPLICATION_CREDENTIALS=/code/google-credentials.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2.1'
 services:
   db-test:
     image: postgis/postgis:16-3.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,9 +45,6 @@ services:
     command: /bin/bash -c './scripts/docker_setup.sh && cd openprescribing && python manage.py check --deploy'
     environment:
       - DJANGO_SETTINGS_MODULE=openprescribing.settings.production
-      - TEST_SUITE=${TEST_SUITE}
-      - BROWSER=${BROWSER}
-      - GOOGLE_APPLICATION_CREDENTIALS=/code/google-credentials.json
     ports:
       - "6080-6580:6080-6580"
       - "6060:6060"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,6 @@ services:
   test:
     image: ghcr.io/bennettoxford/openprescribing-py312-test:latest
     command: /bin/bash -c './scripts/docker_setup.sh test && cd openprescribing && make test'
-    env_file: environment-docker
     environment:
       - DJANGO_SETTINGS_MODULE=openprescribing.settings.test
       - BROWSER=${BROWSER}
@@ -41,7 +40,6 @@ services:
   test-production:
     image: ghcr.io/bennettoxford/openprescribing-py312-base:latest
     command: /bin/bash -c './scripts/docker_setup.sh production && cd openprescribing && python manage.py check --deploy --settings openprescribing.settings.production'
-    env_file: environment-docker
     environment:
       - TEST_SUITE=${TEST_SUITE}
       - BROWSER=${BROWSER}
@@ -57,7 +55,6 @@ services:
   dev:
     image: ghcr.io/bennettoxford/openprescribing-py312-test:latest
     command: /bin/bash -c './scripts/docker_setup.sh local &&  cd openprescribing && /bin/bash -l'
-    env_file: environment-docker
     ports:
       - "8000:8000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
     volumes:
       - .:/code
     depends_on:
-      - db-dev
+      - db-test
 
 volumes:
   postgres_data:

--- a/environment-docker
+++ b/environment-docker
@@ -1,3 +1,0 @@
-POSTGRES_PASSWORD=pass
-POSTGRES_USER=user
-POSTGRES_DB=openprescribing-test

--- a/environment-test
+++ b/environment-test
@@ -1,7 +1,7 @@
 DB_NAME=openprescribing-test
 DB_USER=user
 DB_PASS=pass
-DB_HOST=db-test
+DB_HOST=postgis
 
 SECRET_KEY=secret_key
 MAILGUN_WEBHOOK_USER=mailgun_webhook_user

--- a/justfile
+++ b/justfile
@@ -3,7 +3,7 @@ set dotenv-path := "environment"
 set positional-arguments
 
 app_service := "test"
-db_service := "db-test"
+db_service := "postgis"
 
 clean:
     uv venv --clear

--- a/justfile
+++ b/justfile
@@ -23,6 +23,24 @@ migrate *args:
 run *args:
     {{ just_executable() }} manage runserver "$@"
 
+run-docker:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Run the web app and database in containers for development. Commands correspond to
+    # those in the "Using Docker" section of README.md, with additional cleanup.
+
+    # Running the service will replace environment with environment-test, so we backup
+    # and rotate environment. We also remove all containers (including dependant
+    # containers) and volumes when this recipe exits to avoid accumulating them over
+    # time.
+    cleanup() {
+        mv environment.bak environment
+        docker compose down
+    }
+    trap 'cleanup' EXIT INT TERM
+    cp environment environment.bak
+    docker compose run --rm --service-ports dev
+
 test *args: db
     #!/usr/bin/env bash
     set -euo pipefail


### PR DESCRIPTION
This PR makes the `docker-compose.yml` file easier to reason about by removing elements that aren't required (principally the `db-dev` service) and by making a few stylistic changes. To help figure out how things should have worked before the changes, and to ensure that they work after the changes, this PR also includes a new `run-docker` recipe. This recipe provides a Docker-based development environment, although the user has to trust that it matches the production environment, which isn't Docker-based, and know how to migrate, start a development server, etc.