### PR TITLE
Don't skip `npm build`

### DIFF
--- a/justfile
+++ b/justfile
@@ -56,7 +56,7 @@ test *args: _environment db
     set -euo pipefail
 
     cd openprescribing
-    SKIP_NPM_BUILD=1 uv run coverage run manage.py test "$@"
+    uv run coverage run manage.py test "$@"
 
 test-functional *args:
     #!/usr/bin/env bash


### PR DESCRIPTION
This seemed like a good idea as it reduced the time it took to run the tests, but it's confusing: tests fail in a clean repo (i.e. when `npm build` hasn't run).