### PR TITLE
Enhancements to `justfile`

### DIFF
--- a/justfile
+++ b/justfile
@@ -160,6 +160,7 @@ assets-build:
 db:
     docker compose up --detach --wait {{ db_service }}
 
+# Remove an existing database container, and its associated network and volume
 @db-clean:
     # need not depend on db, because a down without a previous up is a no-op
     @docker compose down --volumes {{ db_service }}

--- a/justfile
+++ b/justfile
@@ -194,7 +194,7 @@ db:
 
 # Access a database shell running inside the database container
 db-shell: db
-    docker compose exec {{ db_service }} psql --username user openprescribing-test
+    docker compose exec {{ db_service }} bash -c 'psql --username "$POSTGRES_USER" "$POSTGRES_DB"'
 
 # Build the base and test images
 [confirm("This will remove the existing base and test images. Do you wish to continue? (y/n)")]

--- a/justfile
+++ b/justfile
@@ -15,6 +15,15 @@ _environment:
         exit 1
     fi
 
+_check-gdal-binary:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if ! command -v gdal --version >/dev/null 2>&1; then
+        echo 'Error: gdal was not found on your PATH.'
+        exit 1
+    fi
+
 clean:
     uv venv --clear
 
@@ -50,7 +59,8 @@ start-docker:
     cp environment environment.bak
     docker compose run --rm --service-ports dev
 
-test *args: _environment db
+# Run the tests (see TESTING.md)
+test *args: _environment _check-gdal-binary db
     #!/usr/bin/env bash
     set -euo pipefail
 

--- a/justfile
+++ b/justfile
@@ -40,11 +40,11 @@ start-docker:
 
     # Running the service will replace environment with environment-test, so we backup
     # and rotate environment. We also remove all containers (including dependant
-    # containers) and volumes when this recipe exits to avoid accumulating them over
-    # time.
+    # containers), networks, and volumes when this recipe exits to avoid accumulating
+    # them over time.
     cleanup() {
         mv environment.bak environment
-        docker compose down
+        docker compose down --volumes
     }
     trap 'cleanup' EXIT INT TERM
     cp environment environment.bak

--- a/justfile
+++ b/justfile
@@ -33,11 +33,10 @@ migrate *args:
 run *args:
     {{ just_executable() }} manage runserver "$@"
 
-run-docker:
+# Start the web app and database containers
+start-docker:
     #!/usr/bin/env bash
     set -euo pipefail
-    # Run the web app and database in containers for development. Commands correspond to
-    # those in the "Using Docker" section of README.md, with additional cleanup.
 
     # Running the service will replace environment with environment-test, so we backup
     # and rotate environment. We also remove all containers (including dependant

--- a/justfile
+++ b/justfile
@@ -24,21 +24,27 @@ _check-gdal-binary:
         exit 1
     fi
 
+# Remove an existing virtual environment
 clean:
     uv venv --clear
 
+# Run the code quality checks but don't modify any files
 check:
     ./scripts/lint.sh
 
+# Install development requirements into the virtual environment
 devenv:
     uv pip sync requirements.txt requirements.dev.txt
 
+# Run `manage.py`
 manage *args: db
     uv run openprescribing/manage.py "$@"
 
+# Run `manage.py migrate`
 migrate *args:
     {{ just_executable() }} manage migrate "$@"
 
+# Run `manage.py runserver`
 run *args:
     {{ just_executable() }} manage runserver "$@"
 
@@ -67,6 +73,7 @@ test *args: _environment _check-gdal-binary db
     cd openprescribing
     uv run coverage run manage.py test "$@"
 
+# Run the functional tests (see TESTING.md)
 test-functional *args:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -81,6 +88,7 @@ test-functional *args:
 
     TEST_SUITE=functional {{ just_executable() }} test "$@"
 
+# Run the non-functional tests (see TESTING.md)
 test-nonfunctional *args:
     TEST_SUITE=nonfunctional {{ just_executable() }} test "$@"
 
@@ -94,6 +102,7 @@ _check-browserstacklocal-binary:
         exit 1
     fi
 
+# Start BrowserStack's local agent (see TESTING.md)
 @start-browserstacklocal: _check-browserstacklocal-binary
     # The force flag kills other instances of the BrowserStackLocal daemon with the same
     # local-identifier. At most, one instance should exist if a previous BrowserStack
@@ -104,6 +113,7 @@ _check-browserstacklocal-binary:
     --key "$BROWSERSTACK_ACCESS_KEY" \
     --local-identifier "$BROWSERSTACK_LOCAL_IDENTIFIER"
 
+# Stop BrowserStack's local agent (see TESTING.md)
 stop-browserstacklocal: _check-browserstacklocal-binary
     BrowserStackLocal --daemon stop --local-identifier "$BROWSERSTACK_LOCAL_IDENTIFIER"
 
@@ -119,15 +129,18 @@ _check-browser-env-var:
         exit 1
     fi
 
+# Run the functional tests using BrowserStack's local agent (see TESTING.md)
 test-browserstack-functional *args: _check-browser-env-var start-browserstacklocal && stop-browserstacklocal
     USE_BROWSERSTACK=1 {{ just_executable() }} test-functional "$@"
 
+# Run the functional tests in a container using BrowserStack's local agent (see TESTING.md)
 test-docker-browserstack-functional: _check-browser-env-var start-browserstacklocal && stop-browserstacklocal
     # USE_BROWSERSTACK isn't passed to the service, but GITHUB_ACTIONS is. Either is
     # used to determine whether the functional tests are run with the BrowserStack local
     # agent (openprescribing.frontend.tests.functional.selenium_base.use_browserstack).
     GITHUB_ACTIONS=1 {{ just_executable() }} test-docker-functional
 
+# Run the tests in a container (see TESTING.md)
 test-docker: _environment
     #!/usr/bin/env bash
     set -euo pipefail
@@ -143,12 +156,15 @@ test-docker: _environment
     # them.
     docker compose run --rm --service-ports {{ app_service }}
 
+# Run the functional tests in a container (see TESTING.md)
 test-docker-functional:
     TEST_SUITE=functional {{ just_executable() }} test-docker
 
+# Run the non-functional tests in a container (see TESTING.md)
 test-docker-nonfunctional:
     TEST_SUITE=nonfunctional {{ just_executable() }} test-docker
 
+# Install the Node.js dependencies
 assets-install:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -159,6 +175,7 @@ assets-install:
     npm install -g less
     npm install
 
+# Build the Node.js assets
 assets-build:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -166,6 +183,7 @@ assets-build:
     cd openprescribing/media/js
     npm run build
 
+# Start the database container
 db:
     docker compose up --detach --wait {{ db_service }}
 
@@ -174,6 +192,7 @@ db:
     # need not depend on db, because a down without a previous up is a no-op
     @docker compose down --volumes {{ db_service }}
 
+# Access a database shell running inside the database container
 db-shell: db
     docker compose exec {{ db_service }} psql --username user openprescribing-test
 

--- a/justfile
+++ b/justfile
@@ -24,6 +24,15 @@ _check-gdal-binary:
         exit 1
     fi
 
+_check-phantomjs-binary:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    if ! command -v phantomjs --version >/dev/null 2>&1; then
+        echo 'Error: phantomjs was not found on your PATH.'
+        exit 1
+    fi
+
 # Remove an existing virtual environment
 clean:
     uv venv --clear
@@ -66,7 +75,7 @@ start-docker:
     docker compose run --rm --service-ports dev
 
 # Run the tests (see TESTING.md)
-test *args: _environment _check-gdal-binary db
+test *args: _environment _check-gdal-binary _check-phantomjs-binary db
     #!/usr/bin/env bash
     set -euo pipefail
 

--- a/justfile
+++ b/justfile
@@ -138,7 +138,7 @@ test-docker-browserstack-functional: _check-browser-env-var start-browserstacklo
     # USE_BROWSERSTACK isn't passed to the service, but GITHUB_ACTIONS is. Either is
     # used to determine whether the functional tests are run with the BrowserStack local
     # agent (openprescribing.frontend.tests.functional.selenium_base.use_browserstack).
-    GITHUB_ACTIONS=1 {{ just_executable() }} test-docker-functional
+    GITHUB_ACTIONS=true {{ just_executable() }} test-docker-functional
 
 # Run the tests in a container (see TESTING.md)
 test-docker: _environment

--- a/justfile
+++ b/justfile
@@ -160,9 +160,9 @@ assets-build:
 db:
     docker compose up --detach --wait {{ db_service }}
 
-db-clean:
+@db-clean:
     # need not depend on db, because a down without a previous up is a no-op
-    docker compose down --volumes {{ db_service }}
+    @docker compose down --volumes {{ db_service }}
 
 db-shell: db
     docker compose exec {{ db_service }} psql --username user openprescribing-test

--- a/justfile
+++ b/justfile
@@ -63,15 +63,13 @@ start-docker:
     set -euo pipefail
 
     # Running the service will replace environment with environment-test, so we backup
-    # and rotate environment. We also remove all containers (including dependant
-    # containers), networks, and volumes when this recipe exits to avoid accumulating
-    # them over time.
-    cleanup() {
-        mv environment.bak environment
-        docker compose down --volumes
-    }
-    trap 'cleanup' EXIT INT TERM
+    # and rotate environment.
     cp environment environment.bak
+    trap 'mv environment.bak environment' EXIT INT TERM
+
+    # Unlike `up`, `run` doesn't create the ports that are specified by
+    # docker-compose.yml by default. These ports are needed for connecting to the Django
+    # development web server, so we pass `--service-ports` to create them.
     docker compose run --rm --service-ports dev
 
 # Run the tests (see TESTING.md)


### PR DESCRIPTION
These make the recipes more coherent, add documentation (visible with `just` or `just --list`), as well as add some nice-to-have checks for missing system dependencies. They're motivated by the need for `justfile` to be helpful to a software developer, rather than to me alone.