### PR TITLE
Remove redundant trap

### DIFF
--- a/justfile
+++ b/justfile
@@ -63,11 +63,6 @@ start-docker:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    # Running the service will replace environment with environment-test, so we backup
-    # and rotate environment.
-    cp environment environment.bak
-    trap 'mv environment.bak environment' EXIT INT TERM
-
     # Unlike `up`, `run` doesn't create the ports that are specified by
     # docker-compose.yml by default. These ports are needed for connecting to the Django
     # development web server, so we pass `--service-ports` to create them.


### PR DESCRIPTION
Following cbcecab5, this trap is no longer required and the associated comment is incorrect. Let's remove them.