### PR TITLE
Set GITHUB_ACTIONS default to empty string

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       - BROWSER=${BROWSER:-placeholder}
       - TEST_SUITE=${TEST_SUITE:-placeholder}
       - GOOGLE_APPLICATION_CREDENTIALS=/code/google-credentials.json
-      - GITHUB_ACTIONS=${GITHUB_ACTIONS:-false}
+      - GITHUB_ACTIONS=${GITHUB_ACTIONS:-}
       - BROWSERSTACK_USERNAME=${BROWSERSTACK_USERNAME:-placeholder}
       - BROWSERSTACK_ACCESS_KEY=${BROWSERSTACK_ACCESS_KEY:-placeholder}
       - BROWSERSTACK_PROJECT_NAME=${BROWSERSTACK_PROJECT_NAME:-placeholder}


### PR DESCRIPTION
In 95e087d24, we set the default value of GITHUB_ACTIONS to "false". Alas, use_browserstack() tests for the truthiness of GITHUB_ACTIONS to determine whether or not to use BrowserStack's local agent; and the truthiness of "false" is True. Hence, running the functional tests in a container would use BrowserStack's local agent, but with the value of BROWSER set to "placeholder", which errored.

The fix is simply to set the default value of GITHUB_ACTIONS to the empty string. Compose won't display a warning, so we still reduce warning fatigue.