### PR TITLE
Ensure consistent test-related envvars

### DIFF
--- a/justfile
+++ b/justfile
@@ -73,6 +73,8 @@ test *args: _environment _check-gdal-binary _check-phantomjs-binary db
     #!/usr/bin/env bash
     set -euo pipefail
 
+    export DJANGO_SETTINGS_MODULE=openprescribing.settings.test
+    export GOOGLE_APPLICATION_CREDENTIALS=google-credentials.json
     cd openprescribing
     uv run coverage run manage.py test "$@"
 


### PR DESCRIPTION
DJANGO_SETTINGS_MODULE and GOOGLE_APPLICATION_CREDENTIALS should be the same for test and test-docker. They are set by docker-compose.yml for test-docker.