### PR TITLE
Use local settings for dev service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,8 @@ services:
   dev:
     image: ghcr.io/bennettoxford/openprescribing-py312-test:latest
     command: /bin/bash -c './scripts/docker_setup.sh &&  cd openprescribing && /bin/bash -l'
+    environment:
+      - DJANGO_SETTINGS_MODULE=openprescribing.settings.local
     ports:
       - "8000:8000"
     volumes:


### PR DESCRIPTION
This makes the dev service (settings.local) consistent with the test-production service (settings.production) and the test service (settings.test). If you run runserver or migrate in the dev service, then it saves you some time.