### PR TITLE
Don't clobber `environment`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ services:
   postgis:
     image: postgis/postgis:16-3.4
     environment:
+      # These values are defined here as well as in justfile (DB_PASS, DB_USER,
+      # DB_NAME). We accept a small amount of redundancy in return for decoupling this
+      # service from other services.
       - POSTGRES_PASSWORD=pass
       - POSTGRES_USER=user
       - POSTGRES_DB=openprescribing-test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,14 @@
 x-shared-environment: &shared-environment
+  # We set default values only for GitHub Actions' benefit. When we replace calls to
+  # `docker compose run` with calls to `just`, then we can remove them.
   DB_HOST: postgis
-  DB_NAME: ${DB_NAME:-}
-  DB_PASS: ${DB_PASS:-}
-  DB_USER: ${DB_USER:-}
-  MAILGUN_API_KEY: ${MAILGUN_API_KEY:-}
-  MAILGUN_WEBHOOK_PASS: ${MAILGUN_WEBHOOK_PASS:-}
-  MAILGUN_WEBHOOK_USER: ${MAILGUN_WEBHOOK_USER:-}
-  SECRET_KEY: ${SECRET_KEY:-}
+  DB_NAME: ${DB_NAME:-openprescribing-test}
+  DB_PASS: ${DB_PASS:-pass}
+  DB_USER: ${DB_USER:-user}
+  MAILGUN_API_KEY: ${MAILGUN_API_KEY:-mailgun_api_key}
+  MAILGUN_WEBHOOK_PASS: ${MAILGUN_WEBHOOK_PASS:-mailgun_webhook_pass}
+  MAILGUN_WEBHOOK_USER: ${MAILGUN_WEBHOOK_USER:-mailgun_webhook_user}
+  SECRET_KEY: ${SECRET_KEY:-secret_key}
 
 services:
   postgis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@ services:
       # These values are defined here as well as in justfile (DB_PASS, DB_USER,
       # DB_NAME). We accept a small amount of redundancy in return for decoupling this
       # service from other services.
-      - POSTGRES_PASSWORD=pass
-      - POSTGRES_USER=user
-      - POSTGRES_DB=openprescribing-test
+      POSTGRES_PASSWORD: pass
+      POSTGRES_USER: user
+      POSTGRES_DB: openprescribing-test
     ports:
       - "5432:5432"
     volumes:
@@ -25,16 +25,16 @@ services:
     image: ghcr.io/bennettoxford/openprescribing-py312-test:latest
     command: /bin/bash -c './scripts/docker_setup.sh && cd openprescribing && make test'
     environment:
-      - DJANGO_SETTINGS_MODULE=openprescribing.settings.test
-      - BROWSER=${BROWSER:-}
-      - TEST_SUITE=${TEST_SUITE:-}
-      - GOOGLE_APPLICATION_CREDENTIALS=/code/google-credentials.json
-      - GITHUB_ACTIONS=${GITHUB_ACTIONS:-}
-      - BROWSERSTACK_USERNAME=${BROWSERSTACK_USERNAME:-}
-      - BROWSERSTACK_ACCESS_KEY=${BROWSERSTACK_ACCESS_KEY:-}
-      - BROWSERSTACK_PROJECT_NAME=${BROWSERSTACK_PROJECT_NAME:-}
-      - BROWSERSTACK_BUILD_NAME=${BROWSERSTACK_BUILD_NAME:-}
-      - BROWSERSTACK_LOCAL_IDENTIFIER=${BROWSERSTACK_LOCAL_IDENTIFIER:-}
+      DJANGO_SETTINGS_MODULE: openprescribing.settings.test
+      BROWSER: ${BROWSER:-}
+      TEST_SUITE: ${TEST_SUITE:-}
+      GOOGLE_APPLICATION_CREDENTIALS: /code/google-credentials.json
+      GITHUB_ACTIONS: ${GITHUB_ACTIONS:-}
+      BROWSERSTACK_USERNAME: ${BROWSERSTACK_USERNAME:-}
+      BROWSERSTACK_ACCESS_KEY: ${BROWSERSTACK_ACCESS_KEY:-}
+      BROWSERSTACK_PROJECT_NAME: ${BROWSERSTACK_PROJECT_NAME:-}
+      BROWSERSTACK_BUILD_NAME: ${BROWSERSTACK_BUILD_NAME:-}
+      BROWSERSTACK_LOCAL_IDENTIFIER: ${BROWSERSTACK_LOCAL_IDENTIFIER:-}
     ports:
       - "6080-6580:6080-6580"
       - "6060:6060"
@@ -48,7 +48,7 @@ services:
     image: ghcr.io/bennettoxford/openprescribing-py312-base:latest
     command: /bin/bash -c './scripts/docker_setup.sh && cd openprescribing && python manage.py check --deploy'
     environment:
-      - DJANGO_SETTINGS_MODULE=openprescribing.settings.production
+      DJANGO_SETTINGS_MODULE: openprescribing.settings.production
     ports:
       - "6080-6580:6080-6580"
       - "6060:6060"
@@ -62,7 +62,7 @@ services:
     image: ghcr.io/bennettoxford/openprescribing-py312-test:latest
     command: /bin/bash -c './scripts/docker_setup.sh &&  cd openprescribing && /bin/bash -l'
     environment:
-      - DJANGO_SETTINGS_MODULE=openprescribing.settings.local
+      DJANGO_SETTINGS_MODULE: openprescribing.settings.local
     ports:
       - "8000:8000"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,14 @@
-services:
+x-shared-environment: &shared-environment
+  DB_HOST: postgis
+  DB_NAME: ${DB_NAME:-}
+  DB_PASS: ${DB_PASS:-}
+  DB_USER: ${DB_USER:-}
+  MAILGUN_API_KEY: ${MAILGUN_API_KEY:-}
+  MAILGUN_WEBHOOK_PASS: ${MAILGUN_WEBHOOK_PASS:-}
+  MAILGUN_WEBHOOK_USER: ${MAILGUN_WEBHOOK_USER:-}
+  SECRET_KEY: ${SECRET_KEY:-}
 
+services:
   postgis:
     image: postgis/postgis:16-3.4
     environment:
@@ -25,6 +34,7 @@ services:
     image: ghcr.io/bennettoxford/openprescribing-py312-test:latest
     command: /bin/bash -c './scripts/docker_setup.sh && cd openprescribing && make test'
     environment:
+      <<: *shared-environment
       DJANGO_SETTINGS_MODULE: openprescribing.settings.test
       BROWSER: ${BROWSER:-}
       TEST_SUITE: ${TEST_SUITE:-}
@@ -48,6 +58,7 @@ services:
     image: ghcr.io/bennettoxford/openprescribing-py312-base:latest
     command: /bin/bash -c './scripts/docker_setup.sh && cd openprescribing && python manage.py check --deploy'
     environment:
+      <<: *shared-environment
       DJANGO_SETTINGS_MODULE: openprescribing.settings.production
     ports:
       - "6080-6580:6080-6580"
@@ -62,6 +73,7 @@ services:
     image: ghcr.io/bennettoxford/openprescribing-py312-test:latest
     command: /bin/bash -c './scripts/docker_setup.sh &&  cd openprescribing && /bin/bash -l'
     environment:
+      <<: *shared-environment
       DJANGO_SETTINGS_MODULE: openprescribing.settings.local
     ports:
       - "8000:8000"

--- a/environment-sample
+++ b/environment-sample
@@ -51,13 +51,3 @@ CF_API_KEY=cf_api_key
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 TRUD_API_KEY=
-
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# Required for running the functional tests with BrowserStack locally
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-BROWSERSTACK_ACCESS_KEY=
-BROWSERSTACK_USERNAME=
-BROWSERSTACK_BUILD_NAME=openprescribing
-BROWSERSTACK_LOCAL_IDENTIFIER=openprescribing
-BROWSERSTACK_PROJECT_NAME=openprescribing

--- a/environment-test
+++ b/environment-test
@@ -1,9 +1,0 @@
-DB_NAME=openprescribing-test
-DB_USER=user
-DB_PASS=pass
-DB_HOST=postgis
-
-SECRET_KEY=secret_key
-MAILGUN_WEBHOOK_USER=mailgun_webhook_user
-MAILGUN_WEBHOOK_PASS=mailgun_webhook_pass
-MAILGUN_API_KEY=mailgun_api_key

--- a/justfile
+++ b/justfile
@@ -100,14 +100,6 @@ test-docker-browserstack-functional $BROWSER: start-browserstacklocal && stop-br
 
 # Run the tests in a container (see TESTING.md)
 test-docker:
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    # Running the service will replace environment with environment-test, so we backup
-    # and rotate environment.
-    cp environment environment.bak
-    trap 'mv environment.bak environment' EXIT INT TERM
-
     # Unlike `up`, `run` doesn't create the ports that are specified by
     # docker-compose.yml by default. These ports are needed for running the functional
     # tests with the BrowserStack local agent, so we pass `--service-ports` to create

--- a/justfile
+++ b/justfile
@@ -6,16 +6,6 @@ dev_service := "dev"
 postgis_service := "postgis"
 test_service := "test"
 
-_environment:
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    if [[ ! -f "environment" ]]; then
-        echo 'I did not find `environment`, so I will create it from `environment-sample`. Please edit `environment` and rerun the just recipe.'
-        cp environment-sample environment
-        exit 1
-    fi
-
 # Remove an existing virtual environment
 clean:
     uv venv --clear
@@ -51,7 +41,7 @@ start-docker:
     docker compose run --rm --service-ports {{ dev_service }}
 
 # Run the tests (see TESTING.md)
-test *args: _environment db
+test *args: db
     #!/usr/bin/env bash
     set -euo pipefail
 
@@ -95,7 +85,7 @@ test-docker-browserstack-functional $BROWSER: start-browserstacklocal && stop-br
     GITHUB_ACTIONS=true {{ just_executable() }} test-docker-functional
 
 # Run the tests in a container (see TESTING.md)
-test-docker: _environment
+test-docker:
     #!/usr/bin/env bash
     set -euo pipefail
 

--- a/justfile
+++ b/justfile
@@ -1,10 +1,24 @@
 set default-list
-set dotenv-path := "environment"
 set positional-arguments
 
 dev_service := "dev"
 postgis_service := "postgis"
 test_service := "test"
+
+# These just variables are exported to recipes as environment variables. The values of
+# the DB_* just/environment variables come from the postgis service (see
+# docker-compose.yml).
+export BROWSERSTACK_BUILD_NAME := ""
+export BROWSERSTACK_LOCAL_IDENTIFIER := ""
+export BROWSERSTACK_PROJECT_NAME := ""
+export DB_NAME := "openprescribing-test"
+export DB_PASS := "pass"
+export DB_USER := "user"
+export DJANGO_SETTINGS_MODULE := "openprescribing.settings.local"
+export MAILGUN_API_KEY := "mailgun_api_key"
+export MAILGUN_WEBHOOK_PASS := "mailgun_webhook_pass"
+export MAILGUN_WEBHOOK_USER := "mailgun_webhook_user"
+export SECRET_KEY := "secret_key"
 
 # Remove an existing virtual environment
 clean:

--- a/openprescribing/Makefile
+++ b/openprescribing/Makefile
@@ -1,5 +1,4 @@
 test :
-	cp ../environment-test ../environment
 	coverage run manage.py test -v 2
 	coverage report
 	cd media/js; npm run test


### PR DESCRIPTION
Previously, calling `make test` would replace `environment` with `environment-test`. This behaviour was harmless when run in CI; annoying when run locally ("Why can't I connect to the database any more?"); and a significant problem if run in production. Who would do such a thing? Well, with flaky tests run on containers that aren't themselves run in production, and with Django's ability to switch between default and test databases, it's not _completely_ unreasonable that someone would. Ouch.

Still can't see someone calling `make test`? Well, `test.command` (i.e. the command that runs when the test service container starts) calls it, so calling `docker compose run test` was equally troublesome.

After realising how enmeshed `environment` is, thanks to [django-dotenv](https://pypi.org/project/django-dotenv/) (latest release, December 11th 2017!), I decided to dispense with `environment` for development and testing. There's some redundancy, as I didn't want to embark on adding `just` to our GitHub Actions jobs, but it's contained within 1b1190fc.