### PR TITLE
Remove checks for system dependencies in `justfile`

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,15 +16,6 @@ _environment:
         exit 1
     fi
 
-_check-gdal-binary:
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    if ! command -v gdal --version >/dev/null 2>&1; then
-        echo 'Error: gdal was not found on your PATH.'
-        exit 1
-    fi
-
 # Remove an existing virtual environment
 clean:
     uv venv --clear
@@ -60,7 +51,7 @@ start-docker:
     docker compose run --rm --service-ports {{ dev_service }}
 
 # Run the tests (see TESTING.md)
-test *args: _environment _check-gdal-binary db
+test *args: _environment db
     #!/usr/bin/env bash
     set -euo pipefail
 

--- a/justfile
+++ b/justfile
@@ -25,15 +25,6 @@ _check-gdal-binary:
         exit 1
     fi
 
-_check-phantomjs-binary:
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    if ! command -v phantomjs --version >/dev/null 2>&1; then
-        echo 'Error: phantomjs was not found on your PATH.'
-        exit 1
-    fi
-
 # Remove an existing virtual environment
 clean:
     uv venv --clear
@@ -69,7 +60,7 @@ start-docker:
     docker compose run --rm --service-ports {{ dev_service }}
 
 # Run the tests (see TESTING.md)
-test *args: _environment _check-gdal-binary _check-phantomjs-binary db
+test *args: _environment _check-gdal-binary db
     #!/usr/bin/env bash
     set -euo pipefail
 

--- a/justfile
+++ b/justfile
@@ -68,18 +68,8 @@ test-functional *args:
 test-nonfunctional *args:
     TEST_SUITE=nonfunctional {{ just_executable() }} test "$@"
 
-_check-browserstacklocal-binary:
-    #!/usr/bin/env bash
-    set -euo pipefail
-
-    if ! command -v BrowserStackLocal --version >/dev/null 2>&1; then
-        echo 'Error: BrowserStackLocal was not found on your PATH.'
-        echo 'You can download it from https://www.browserstack.com/docs/local-testing/releases-and-downloads'
-        exit 1
-    fi
-
 # Start BrowserStack's local agent (see TESTING.md)
-@start-browserstacklocal: _check-browserstacklocal-binary
+start-browserstacklocal:
     # The force flag kills other instances of the BrowserStackLocal daemon with the same
     # local-identifier. At most, one instance should exist if a previous BrowserStack
     # recipe failed.
@@ -90,7 +80,7 @@ _check-browserstacklocal-binary:
     --local-identifier "$BROWSERSTACK_LOCAL_IDENTIFIER"
 
 # Stop BrowserStack's local agent (see TESTING.md)
-stop-browserstacklocal: _check-browserstacklocal-binary
+stop-browserstacklocal:
     BrowserStackLocal --daemon stop --local-identifier "$BROWSERSTACK_LOCAL_IDENTIFIER"
 
 _check-browser-env-var:


### PR DESCRIPTION
I'd hoped these would make local development easier by exiting tasks early when their system dependencies weren't met. In hindsight, this was a mistake: trying to guess which tasks needed which system dependencies is hard. The extra complexity isn't worth the maintenance cost. Better to let the tasks themselves error, eventually.

I haven't removed `_check-browser-env-var` in this PR because I think we can achieve the same with a recipe parameter prefixed with a `$`. Hence, it's a replacement rather than a removal.