### PR TITLE
Add notes

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,3 +1,9 @@
+> [!NOTE]
+> If you're developing OpenPrescribing,
+> then start by running `just` and learning about the recipes.
+> Consider reading [TESTING.md](TESTING.md), too.
+> This information is dated, but it's retained because it's useful.
+
 This document describes the local setup process for developers.
 
 It is a work in progress and only has instructions for macOS for now.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Website code for https://openprescribing.net - a Django application that provide
 
 Information about data sources used on OpenPrescribing can be found [here](https://openprescribing.net/about/).
 
+> [!NOTE]
+> If you're developing OpenPrescribing,
+> then start by running `just` and learning about the recipes.
+> Consider reading [TESTING.md](TESTING.md), too.
+> This information is dated, but it's retained because it's useful.
+
 # Set up the application
 
 You can install the application dependencies either on bare metal or


### PR DESCRIPTION
I'd like to retain, for the moment, the information in DEVELOPERS.md and README.md. However, I'd also like developers to start with `just` and TESTING.md. Hence these notes (alerts, callouts, or admonitions).