### PR TITLE
Fix running the functional tests with BrowserStackLocal

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -34,7 +34,7 @@ It sits between a Django live server and BrowserStackCloud.
 To run the functional tests with BrowserStackLocal:
 
 * sign in to <https://www.browserstack.com/> with Google;
-* copy your local testing username and access key from the Settings page;
+* copy your username and access key from the Settings page;
 * pass your access key to BrowserStack's local agent: `start-browserstacklocal $BROWSERSTACK_ACCESS_KEY='...'`;
 * and pass your username and access key to either `just test-functional` or `just test-docker-functional`.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -10,8 +10,8 @@ with or without BrowserStackLocal (see below).
 Let's consider the four cases.
 Functional tests can be run:
 
-* locally with BrowserStackLocal: `BROWSER='...' just test-browserstack-functional`
-* in a container with BrowserStackLocal: `BROWSER='...' just test-docker-browserstack-functional`
+* locally with BrowserStackLocal: `$BROWSER='...' $BROWSERSTACK_ACCESS_KEY='...' $BROWSERSTACK_USERNAME='...' just test-browserstack-functional`
+* in a container with BrowserStackLocal: `$BROWSER='...' $BROWSERSTACK_ACCESS_KEY='...' $BROWSERSTACK_USERNAME='...' just test-docker-browserstack-functional`
 * locally without BrowserStackLocal: `just test-functional`
 * in a container without BrowserStackLocal: `just test-docker-functional`
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -35,7 +35,8 @@ To run the functional tests with BrowserStackLocal:
 
 * sign in to <https://www.browserstack.com/> with Google;
 * copy your local testing username and access key from the Settings page;
-* and paste these values into the `environment` file.
+* pass your access key to BrowserStack's local agent: `start-browserstacklocal $BROWSERSTACK_ACCESS_KEY='...'`;
+* and pass your username and access key to either `just test-functional` or `just test-docker-functional`.
 
 ### Django live server and `0.0.0.0`
 

--- a/justfile
+++ b/justfile
@@ -87,11 +87,11 @@ stop-browserstacklocal:
     BrowserStackLocal --daemon stop --local-identifier "$BROWSERSTACK_LOCAL_IDENTIFIER"
 
 # Run the functional tests using BrowserStack's local agent (see TESTING.md)
-test-browserstack-functional $BROWSER *args: start-browserstacklocal && stop-browserstacklocal
+test-browserstack-functional $BROWSER $BROWSERSTACK_ACCESS_KEY $BROWSERSTACK_USERNAME *args: start-browserstacklocal && stop-browserstacklocal
     USE_BROWSERSTACK=1 {{ just_executable() }} test-functional {{ args }}
 
 # Run the functional tests in a container using BrowserStack's local agent (see TESTING.md)
-test-docker-browserstack-functional $BROWSER: start-browserstacklocal && stop-browserstacklocal
+test-docker-browserstack-functional $BROWSER $BROWSERSTACK_ACCESS_KEY $BROWSERSTACK_USERNAME: start-browserstacklocal && stop-browserstacklocal
     # USE_BROWSERSTACK isn't passed to the service, but GITHUB_ACTIONS is. Either is
     # used to determine whether the functional tests are run with the BrowserStack local
     # agent (openprescribing.frontend.tests.functional.selenium_base.use_browserstack).

--- a/justfile
+++ b/justfile
@@ -72,26 +72,15 @@ test-nonfunctional *args:
     TEST_SUITE=nonfunctional {{ just_executable() }} test {{ args }}
 
 # Start BrowserStack's local agent (see TESTING.md)
-start-browserstacklocal:
-    # The force flag kills other instances of the BrowserStackLocal daemon with the same
-    # local-identifier. At most, one instance should exist if a previous BrowserStack
-    # recipe failed.
-    @BrowserStackLocal \
-    --daemon start \
-    --force \
-    --key "$BROWSERSTACK_ACCESS_KEY" \
-    --local-identifier "$BROWSERSTACK_LOCAL_IDENTIFIER"
-
-# Stop BrowserStack's local agent (see TESTING.md)
-stop-browserstacklocal:
-    BrowserStackLocal --daemon stop --local-identifier "$BROWSERSTACK_LOCAL_IDENTIFIER"
+start-browserstacklocal $BROWSERSTACK_ACCESS_KEY:
+    BrowserStackLocal --key "$BROWSERSTACK_ACCESS_KEY"
 
 # Run the functional tests using BrowserStack's local agent (see TESTING.md)
-test-browserstack-functional $BROWSER $BROWSERSTACK_ACCESS_KEY $BROWSERSTACK_USERNAME *args: start-browserstacklocal && stop-browserstacklocal
+test-browserstack-functional $BROWSER $BROWSERSTACK_ACCESS_KEY $BROWSERSTACK_USERNAME *args:
     USE_BROWSERSTACK=1 {{ just_executable() }} test-functional {{ args }}
 
 # Run the functional tests in a container using BrowserStack's local agent (see TESTING.md)
-test-docker-browserstack-functional $BROWSER $BROWSERSTACK_ACCESS_KEY $BROWSERSTACK_USERNAME: start-browserstacklocal && stop-browserstacklocal
+test-docker-browserstack-functional $BROWSER $BROWSERSTACK_ACCESS_KEY $BROWSERSTACK_USERNAME:
     # USE_BROWSERSTACK isn't passed to the service, but GITHUB_ACTIONS is. Either is
     # used to determine whether the functional tests are run with the BrowserStack local
     # agent (openprescribing.frontend.tests.functional.selenium_base.use_browserstack).

--- a/justfile
+++ b/justfile
@@ -1,5 +1,4 @@
 set default-list
-set positional-arguments
 
 dev_service := "dev"
 postgis_service := "postgis"
@@ -34,15 +33,15 @@ devenv:
 
 # Run `manage.py`
 manage *args: db
-    uv run openprescribing/manage.py "$@"
+    uv run openprescribing/manage.py {{ args }}
 
 # Run `manage.py migrate`
 migrate *args:
-    {{ just_executable() }} manage migrate "$@"
+    {{ just_executable() }} manage migrate {{ args }}
 
 # Run `manage.py runserver`
 run *args:
-    {{ just_executable() }} manage runserver "$@"
+    {{ just_executable() }} manage runserver {{ args }}
 
 # Start the web app and database containers
 start-docker:
@@ -62,15 +61,15 @@ test *args: db
     export DJANGO_SETTINGS_MODULE=openprescribing.settings.test
     export GOOGLE_APPLICATION_CREDENTIALS=google-credentials.json
     cd openprescribing
-    uv run coverage run manage.py test "$@"
+    uv run coverage run manage.py test {{ args }}
 
 # Run the functional tests (see TESTING.md)
 test-functional *args:
-    TEST_SUITE=functional {{ just_executable() }} test "$@"
+    TEST_SUITE=functional {{ just_executable() }} test {{ args }}
 
 # Run the non-functional tests (see TESTING.md)
 test-nonfunctional *args:
-    TEST_SUITE=nonfunctional {{ just_executable() }} test "$@"
+    TEST_SUITE=nonfunctional {{ just_executable() }} test {{ args }}
 
 # Start BrowserStack's local agent (see TESTING.md)
 start-browserstacklocal:
@@ -89,7 +88,7 @@ stop-browserstacklocal:
 
 # Run the functional tests using BrowserStack's local agent (see TESTING.md)
 test-browserstack-functional $BROWSER *args: start-browserstacklocal && stop-browserstacklocal
-    USE_BROWSERSTACK=1 {{ just_executable() }} test-functional "$@"
+    USE_BROWSERSTACK=1 {{ just_executable() }} test-functional {{ args }}
 
 # Run the functional tests in a container using BrowserStack's local agent (see TESTING.md)
 test-docker-browserstack-functional $BROWSER: start-browserstacklocal && stop-browserstacklocal


### PR DESCRIPTION
Running the functional tests with BrowserStackLocal is a pain, but the complexity of subsequent dependencies and running BrowserStackLocal as a daemon, not to mention my misunderstanding positional arguments, didn't help. Here, I've removed the complexity at the expense of having to start BrowserStackLocal separately, and having to pass the access key and username. I think that both can be avoided by starting [BrowserStackLocal](https://hub.docker.com/r/browserstack/local) in a container, which would also remove the need to download a binary. For now, however, I'm going to make the current approach work, rather than take a different approach entirely.