### PR TITLE
Reject invalid org_details query parameters

### DIFF
--- a/openprescribing/api/views_org_details.py
+++ b/openprescribing/api/views_org_details.py
@@ -7,6 +7,8 @@ from rest_framework.response import Response
 
 from . import view_utils as utils
 
+ALLOWED_QUERY_PARAMS = {"format", "keys", "org", "org_type"}
+
 STATS_COLUMN_WHITELIST = (
     "total_list_size",
     "astro_pu_items",
@@ -20,11 +22,17 @@ class KeysNotValid(APIException):
     default_detail = "The keys you provided are not supported"
 
 
+class QueryParamsNotValid(APIException):
+    status_code = 400
+    default_detail = "The query parameters you provided are not supported"
+
+
 @api_view(["GET"])
 def org_details(request, format=None):
     """
     Get list size and ASTRO-PU by month, for CCGs or practices.
     """
+    _validate_query_params(request.query_params)
     org_type = request.GET.get("org_type", None)
     org_type = utils.translate_org_type(org_type)
     keys = utils.param_to_list(request.query_params.get("keys", []))
@@ -34,6 +42,18 @@ def org_details(request, format=None):
     orgs = _get_orgs(org_type, org_codes)
     data = _get_practice_stats_entries(keys, org_type, orgs)
     return Response(list(data))
+
+
+def _validate_query_params(query_params):
+    invalid_params = sorted(set(query_params) - ALLOWED_QUERY_PARAMS)
+    if not invalid_params:
+        return
+
+    if len(invalid_params) == 1:
+        detail = f"{invalid_params[0]} is not a valid query parameter"
+    else:
+        detail = f"{', '.join(invalid_params)} are not valid query parameters"
+    raise QueryParamsNotValid(detail)
 
 
 def _get_orgs(org_type, org_codes):

--- a/openprescribing/frontend/tests/test_api_org_details_query_params.py
+++ b/openprescribing/frontend/tests/test_api_org_details_query_params.py
@@ -1,0 +1,32 @@
+import csv
+
+from .api_test_base import ApiTestBase
+
+
+class TestAPIOrgDetailsQueryParams(ApiTestBase):
+    def test_api_view_org_details_rejects_unknown_query_params(self):
+        for param in ("org_code", "org_id", "q", "unexpected"):
+            with self.subTest(param=param):
+                url = self.api_prefix
+                url += f"/org_details?format=csv&org_type=pcn&{param}=U81825"
+                response = self.client.get(url, follow=True)
+
+                self.assertEqual(response.status_code, 400)
+                rows = list(
+                    csv.DictReader(response.content.decode("utf8").splitlines())
+                )
+                self.assertEqual(
+                    rows[0]["detail"], f"{param} is not a valid query parameter"
+                )
+
+    def test_api_view_org_details_sorts_multiple_unknown_query_params(self):
+        url = self.api_prefix
+        url += "/org_details?format=csv&z=1&org_code=U81825"
+        response = self.client.get(url, follow=True)
+
+        self.assertEqual(response.status_code, 400)
+        rows = list(csv.DictReader(response.content.decode("utf8").splitlines()))
+        self.assertEqual(
+            rows[0]["detail"],
+            "org_code, z are not valid query parameters",
+        )


### PR DESCRIPTION
## Summary

- reject unsupported query parameter names on `/api/1.0/org_details/`
- return `400` before organisation lookup or matrix queries
- cover the known invalid aliases and arbitrary unknown query keys

## Why

Unknown parameters such as `org_code`, `org_id` and `q` were silently ignored. A caller expecting filtering could therefore trigger the full, relatively expensive organisation dataset.

The supported query-parameter contract remains `format`, `keys`, `org` and `org_type`. JSON/CSV query negotiation and `.json`/`.csv` suffixes remain supported.

## Validation

The submitted change is commit `4a5ee5f7148849a07e0904e893fb1323ba55e7cb`.

- [Exact-head contract audit](https://github.com/AyobamiH/openprescribing/actions/runs/33164199408): 22 endpoint and audit tests passed, including JSON, CSV, a `.csv` suffix, the supported parameter set, sorted multi-key errors, and assertions that invalid requests do not reach organisation lookup or matrix work; candidate lint also passed.
- [Merge-base regression proof](https://github.com/AyobamiH/openprescribing/actions/runs/33118758758): the new regression tests fail against the PR base with `200 != 400` for every invalid key.
- [Candidate validation](https://github.com/AyobamiH/openprescribing/actions/runs/33119605336) and [merge-base parity](https://github.com/AyobamiH/openprescribing/actions/runs/33119550983): focused tests and lint pass on the candidate; both broad suites have the same 10 Google-credential-only errors and no assertion failures.
- [Production settings check](https://github.com/AyobamiH/openprescribing/actions/runs/33119450503): passed.
- [Upstream PR workflow](https://github.com/bennettoxford/openprescribing/actions/runs/33120869414): GitHub reports `action_required` with zero jobs because the external-fork workflow requires maintainer approval; this is not a test failure.

Closes #5544
