### PR TITLE
Reject invalid tariff query parameters

### DIFF
--- a/openprescribing/api/views_spending.py
+++ b/openprescribing/api/views_spending.py
@@ -20,6 +20,8 @@ from rest_framework.response import Response
 
 from . import view_utils as utils
 
+ALLOWED_TARIFF_QUERY_PARAMS = {"codes", "format"}
+
 
 class NotValid(APIException):
     status_code = 400
@@ -283,8 +285,22 @@ def ghost_generics(request, format=None):
     return response
 
 
+def _validate_tariff_query_params(query_params):
+    invalid_params = sorted(set(query_params) - ALLOWED_TARIFF_QUERY_PARAMS)
+    if not invalid_params:
+        return
+
+    if len(invalid_params) == 1:
+        detail = f"{invalid_params[0]} is not a valid query parameter"
+    else:
+        detail = f"{', '.join(invalid_params)} are not valid query parameters"
+    raise NotValid(detail)
+
+
 @api_view(["GET"])
 def tariff(request, format=None):
+    _validate_tariff_query_params(request.query_params)
+
     # This view uses raw SQL as we cannot produce the LEFT OUTER JOIN using the
     # ORM.
     codes = utils.param_to_list(request.query_params.get("codes", []))

--- a/openprescribing/frontend/tests/test_api_spending.py
+++ b/openprescribing/frontend/tests/test_api_spending.py
@@ -89,6 +89,34 @@ class TestAPISpendingViewsTariff(ApiTestBase):
         rows = self._rows_from_api(url)
         self.assertEqual(len(rows), 3)
 
+    def test_tariff_rejects_unknown_query_params(self):
+        for param in ("name", "code", "unexpected"):
+            with self.subTest(param=param):
+                url = self.api_prefix
+                url += f"/tariff?format=csv&{param}=Gabapentin"
+                response = self.client.get(url, follow=True)
+
+                self.assertEqual(response.status_code, 400)
+                rows = list(
+                    csv.DictReader(response.content.decode("utf8").splitlines())
+                )
+                self.assertEqual(
+                    rows[0]["detail"],
+                    f"{param} is not a valid query parameter",
+                )
+
+    def test_tariff_sorts_multiple_unknown_query_params(self):
+        url = self.api_prefix
+        url += "/tariff?format=csv&z=1&name=Gabapentin"
+        response = self.client.get(url, follow=True)
+
+        self.assertEqual(response.status_code, 400)
+        rows = list(csv.DictReader(response.content.decode("utf8").splitlines()))
+        self.assertEqual(
+            rows[0]["detail"],
+            "name, z are not valid query parameters",
+        )
+
 
 class TestSpending(ApiTestBase):
     def _get(self, params):


### PR DESCRIPTION
## Summary

- reject unsupported query parameter names on `/api/1.0/tariff/`
- return `400` before the raw tariff query runs
- preserve unfiltered full-tariff requests and valid `codes` filtering

## Why

Parameters such as `name` and `code` were silently ignored. A caller expecting filtering could therefore trigger the full, relatively expensive tariff response.

The supported query-parameter contract remains `format` and `codes`. JSON/CSV query negotiation and `.json`/`.csv` suffixes remain supported. A valid unfiltered request retains the existing eight-hour public cache header; filtered requests remain uncached.

## Validation

The submitted change is commit `18d5c44d5f37b2feeef92a473f9bde64a56a43ea` against current upstream `main` at `3fb87c3c2e42f1d410ccc2227438900e4d861a6e`.

- [Exact-head contract audit](https://github.com/AyobamiH/openprescribing/actions/runs/33164163002): 12 endpoint and audit tests passed, including JSON, CSV, a `.csv` suffix, valid `codes` filtering, the cacheable unfiltered response, sorted multi-key errors, and assertions that rejected requests do not reach raw SQL; candidate lint also passed.
- [Candidate validation](https://github.com/AyobamiH/openprescribing/actions/runs/33125259891): lint and six focused tariff tests passed; the broad suite ran 585 tests and its only errors were the 10 expected missing-Google-credentials errors, with no assertion failures; the production deployment settings check completed successfully.
- [Merge-base regression proof](https://github.com/AyobamiH/openprescribing/actions/runs/33125011202): the two new tests produced four expected `200 != 400` failures against `3fb87c3c2e42f1d410ccc2227438900e4d861a6e`. The workflow is marked failed only because cleanup could not delete a Docker-owned temporary worktree after the regression assertions had passed.
- [Upstream PR workflow](https://github.com/bennettoxford/openprescribing/actions/runs/33126476592): GitHub reports `action_required` with zero jobs because the external-fork workflow requires maintainer approval; this is not a test failure.

Closes #5545
