### PR TITLE
Update homepage English Prescribing Dataset link

### DIFF
--- a/openprescribing/templates/index.html
+++ b/openprescribing/templates/index.html
@@ -14,7 +14,7 @@
 
     <h1>Explore England's prescribing data</h1>
 
-    <p>Every month, the NHS in England publishes <a href="https://opendata.nhsbsa.net/dataset/english-prescribing-data-epd">anonymised data</a> about prescriptions issued by GPs. But the raw files are large and unwieldy, with around 17 million rows of data per month. We've made it easier for everyone to explore - supporting safer, more efficient prescribing.</p>
+    <p>Every month, the NHS in England publishes <a href="https://opendata.nhsbsa.net/dataset/english-prescribing-dataset-epd-with-snomed-code">anonymised data</a> about prescriptions issued by GPs. But the raw files are large and unwieldy, with around 17 million rows of data per month. We've made it easier for everyone to explore - supporting safer, more efficient prescribing.</p>
 
     <p>How to cite: If you use our data or graphs, please cite as <em>OpenPrescribing.net, Bennett Institute for Applied Data Science, University of Oxford, {% current_time "%Y" %}</em> so that others can find us and use our tools.</p>
 


### PR DESCRIPTION
## Summary

- update the homepage link from the retired English Prescribing Dataset to the current EPD with SNOMED dataset
- keep the homepage wording unchanged
- align the public destination with the dataset package used by the prescribing importer

## Scope

This intentionally changes only the homepage link reported in #5536. The FAQ link appears in an answer about accessing older data, so it remains outside this focused correction.

## Validation

Validated the exact PR head, [`2e8c7c1`](https://github.com/AyobamiH/openprescribing/commit/2e8c7c1b5bb6feb96847ede52f4bae686bd7c368), against base [`3fb87c3`](https://github.com/bennettoxford/openprescribing/commit/3fb87c3c2e42f1d410ccc2227438900e4d861a6e) in [GitHub Actions run 33188272399](https://github.com/AyobamiH/openprescribing/actions/runs/33188272399):

- `scripts/lint.sh`
- parsed the homepage HTML and confirmed exactly one current dataset link and no retired dataset link
- confirmed the destination slug matches `fetch_prescribing_data.py`
- confirmed the diff contains only `openprescribing/templates/index.html`
- `git diff --check origin/main...HEAD`
- clean tracked working state

NHSBSA's [Open Data Portal](https://www.nhsbsa.nhs.uk/access-our-data-products/open-data-portal-odp) and [release calendar](https://www.nhsbsa.nhs.uk/data-release-calendar) identify the predecessor EPD as retired and the EPD with SNOMED code as the monthly dataset.

The upstream [OpenPrescribing CI run](https://github.com/bennettoxford/openprescribing/actions/runs/33166478587) is currently `action_required` and has not executed any jobs; it still requires maintainer approval.

Closes #5536
