### PR TITLE
Run BrowserStackLocal in container

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,9 +22,14 @@ jobs:
         env:
           GOOGLE_CLOUD_GITHUB_ACTIONS_PASSPHRASE: ${{ secrets.GOOGLE_CLOUD_GITHUB_ACTIONS_PASSPHRASE }}
       - name: Unit tests
-        run: docker compose run --service-ports test && docker compose run --service-ports test-production
+        run: docker compose run test && docker compose run --service-ports test-production
         env:
           TEST_SUITE: nonfunctional
+            # We set these because the test service depends on the
+            # browserstacklocal-test service for its network, and the latter won't start
+            # without them.
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       - name: Notify slack failure
         if: failure()
         env:
@@ -42,18 +47,6 @@ jobs:
       matrix:
         browser: [ "Edge:latest:Windows:10", "Firefox:latest:OS X:Catalina" ]
     steps:
-      - name: 'BrowserStack Env Setup'
-        uses: 'browserstack/github-actions/setup-env@master'
-        with:
-          username:  ${{ secrets.BROWSERSTACK_USERNAME }}
-          access-key: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-          build-name: BUILD_INFO
-          project-name: REPO_NAME
-      - name: 'BrowserStack Local Tunnel Setup'
-        uses: 'browserstack/github-actions/setup-local@master'
-        with:
-          local-testing: start
-          local-identifier: random
       - name: Checkout
         uses: actions/checkout@v7
       - name: Retrieve Google Cloud credentials
@@ -61,14 +54,12 @@ jobs:
         env:
           GOOGLE_CLOUD_GITHUB_ACTIONS_PASSPHRASE: ${{ secrets.GOOGLE_CLOUD_GITHUB_ACTIONS_PASSPHRASE }}
       - name: Functional tests
-        run: docker compose run --service-ports test
+        run: docker compose run test
         env:
           TEST_SUITE: functional
           BROWSER: ${{ matrix.browser }}
-      - name: 'BrowserStackLocal Stop'
-        uses: 'browserstack/github-actions/setup-local@master'
-        with:
-          local-testing: stop
+          BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       - name: Notify slack failure
         if: failure()
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,6 @@ openprescribing/pipeline/test-data/log.json
 openprescribing/pipeline/e2e-test-data/data
 openprescribing/pipeline/e2e-test-data/log.json
 
-bin/BrowserStackLocal*
-
 # System files
 *.py[co]
 *.egg*

--- a/TESTING.md
+++ b/TESTING.md
@@ -7,13 +7,18 @@ There are two types of test: functional and non-functional.
 The functional tests use Selenium to make requests to a [Django live server][].
 They can be run locally (the host system) or in a container (the guest system),
 with or without BrowserStackLocal (see below).
+BrowserStackLocal is always run in a container.
 Let's consider the four cases.
 Functional tests can be run:
 
 * locally with BrowserStackLocal: `just test-browserstack-functional`
+  The functional tests are run against the web browser given by `BROWSER` (see below).
 * in a container with BrowserStackLocal: `just test-docker-browserstack-functional`
+  The functional tests are run against the web browser given by `BROWSER` (see below).
 * locally without BrowserStackLocal: `just test-functional`
+  The functional tests are run against the local Firefox web browser.
 * in a container without BrowserStackLocal: `just test-docker-functional`
+  The functional tests are run against the container's Firefox web browser.
 
 Of these, the "in a container with BrowserStackLocal" case is how functional tests are run in CI.
 
@@ -21,6 +26,8 @@ Of these, the "in a container with BrowserStackLocal" case is how functional tes
 
 [BrowserStackLocal][] is BrowserStack's local agent.
 It sits between a Django live server and BrowserStackCloud.
+See "[How Local Testing works][]" for more information about BrowserStackLocal,
+including useful and interesting infrastructure and data flow diagrams.
 
 To run the functional tests with BrowserStackLocal:
 
@@ -44,46 +51,7 @@ For example:
 See the "[Select browsers and devices][]" page for values.
 See `.github/workflows/main.yml` for values used in CI.
 
-Finally, start BrowserStackLocal: `just browserstacklocal`.
-
-### Django live server and `0.0.0.0`
-
-The functional tests use `SeleniumTestCase`, which inherits from `LiveServerTestCase`.
-`LiveServerTestCase` starts a [Django live server][] on setup and stops it on teardown.
-`LiveServerTestCase.host` is used as a server bind address *and* as a client destination address.
-By default, `LiveServerTestCase.host` is `localhost`.
-However, `SeleniumTestCase.host` is `0.0.0.0`.
-
-When used as a server bind address, `0.0.0.0` means "all local interfaces".
-When used as a client destination address, `0.0.0.0` is invalid.
-However, it's important to know that:
-
-* on some systems, requests to connect to `0.0.0.0` are treated as requests to connect to `localhost`,
-  if a server is bound on the system.
-* BrowserStackLocal seems to do the same.
-* a server should bind to `0.0.0.0` in a container,
-  such that it can be easily reached from the host system.
-
-Let's consider the four cases again.
-Functional tests can be run:
-
-* locally with BrowserStackLocal.
-  Either the system or BrowserStackLocal maps `0.0.0.0` to `localhost`.
-  A connection is established.
-* in a container with BrowserStackLocal.
-  As above.
-  A connection is established.
-* locally without BrowserStackLocal.
-  The system may or may not map `0.0.0.0` to `localhost`.
-  A connection may or may not be established.
-* in a container without BrowserStackLocal.
-  As above, remembering that "local" means "local to the container",
-  rather than "local to the host system".
-  A connection may or may not be established.
-
-Relying on either the system or BrowserStackLocal to map `0.0.0.0` to `localhost` is unwise,
-but not doing so means modifying the functional tests.
-
 [BrowserStackLocal]: https://www.browserstack.com/docs/automate/selenium/local-testing-introduction?fw-lang=python
 [Django live server]: https://docs.djangoproject.com/en/4.2/topics/testing/tools/#django.test.LiveServerTestCase
+[How Local Testing works]: https://www.browserstack.com/docs/local-testing/how-local-testing-works
 [Select browsers and devices]: https://www.browserstack.com/docs/automate/selenium/select-browsers-and-devices

--- a/TESTING.md
+++ b/TESTING.md
@@ -7,7 +7,6 @@ There are two types of test: functional and non-functional.
 The functional tests use Selenium to make requests to a [Django live server][].
 They can be run locally (the host system) or in a container (the guest system),
 with or without BrowserStackLocal (see below).
-BrowserStackLocal is run locally.
 Let's consider the four cases.
 Functional tests can be run:
 
@@ -22,12 +21,8 @@ Of these, the "in a container with BrowserStackLocal" case is how functional tes
 
 [BrowserStackLocal][] is BrowserStack's local agent.
 It sits between a Django live server and BrowserStackCloud.
-For more information, including helpful diagrams, see the "[How local testing works][]" page.
 
-To run the functional tests with BrowserStackLocal,
-download the zipped binary for your operating system from the "[Releases and downloads][]" page.
-Unzip it and move it to the `bin` directory.
-Next:
+To run the functional tests with BrowserStackLocal:
 
 * sign in to <https://www.browserstack.com/> with Google;
 * register for the open source program at <https://www.browserstack.com/open-source>;
@@ -91,6 +86,4 @@ but not doing so means modifying the functional tests.
 
 [BrowserStackLocal]: https://www.browserstack.com/docs/automate/selenium/local-testing-introduction?fw-lang=python
 [Django live server]: https://docs.djangoproject.com/en/4.2/topics/testing/tools/#django.test.LiveServerTestCase
-[How local testing works]: https://www.browserstack.com/docs/local-testing/how-local-testing-works
-[Releases and downloads]: https://www.browserstack.com/docs/local-testing/releases-and-downloads
 [Select browsers and devices]: https://www.browserstack.com/docs/automate/selenium/select-browsers-and-devices

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,14 @@ x-shared-environment: &shared-environment
   MAILGUN_WEBHOOK_USER: ${MAILGUN_WEBHOOK_USER:-mailgun_webhook_user}
   SECRET_KEY: ${SECRET_KEY:-secret_key}
 
+x-browserstacklocal: &browserstacklocal
+  image: browserstack/local:latest
+  # We disable the dashboard because 1) It's not that useful; and 2) We might want
+  # browserstacklocal and browserstacklocal-test to run simultaneously (they have
+  # different network namespaces). However, only the container that started first would
+  # bind the dashboard to localhost; the container that started second would error.
+  command: ["--key", "${BROWSERSTACK_ACCESS_KEY:-}", "--disable-dashboard"]
+
 services:
   postgis:
     image: postgis/postgis:16-3.4
@@ -32,6 +40,13 @@ services:
       start_period: 30s
       start_interval: 5s
 
+  browserstacklocal:
+    <<: *browserstacklocal
+    network_mode: "host"
+
+  browserstacklocal-test:
+    <<: *browserstacklocal
+
   test:
     image: ghcr.io/bennettoxford/openprescribing-py312-test:latest
     command: /bin/bash -c './scripts/docker_setup.sh && cd openprescribing && make test'
@@ -48,14 +63,14 @@ services:
       BROWSERSTACK_PROJECT_NAME: ${BROWSERSTACK_PROJECT_NAME:-}
       BROWSERSTACK_BUILD_NAME: ${BROWSERSTACK_BUILD_NAME:-}
       BROWSERSTACK_LOCAL_IDENTIFIER: ${BROWSERSTACK_LOCAL_IDENTIFIER:-}
-    ports:
-      - "6080-6580:6080-6580"
-      - "6060:6060"
+    network_mode: "service:browserstacklocal-test"
     volumes:
       - .:/code
     depends_on:
       postgis:
         condition: service_healthy
+      browserstacklocal-test:
+        condition: service_started
 
   test-production:
     image: ghcr.io/bennettoxford/openprescribing-py312-base:latest

--- a/justfile
+++ b/justfile
@@ -1,6 +1,7 @@
 set default-list
 set dotenv-load
 
+browserstacklocal_service := "browserstacklocal"
 dev_service := "dev"
 postgis_service := "postgis"
 test_service := "test"
@@ -74,10 +75,10 @@ test-nonfunctional *args:
 
 # Start BrowserStack's local agent (see TESTING.md)
 browserstacklocal:
-    BrowserStackLocal --key "$BROWSERSTACK_ACCESS_KEY"
+    docker compose up --detach --wait {{ browserstacklocal_service }}
 
 # Run the functional tests using BrowserStack's local agent (see TESTING.md)
-test-browserstack-functional *args:
+test-browserstack-functional *args: browserstacklocal
     USE_BROWSERSTACK=1 {{ just_executable() }} test-functional {{ args }}
 
 # Run the functional tests in a container using BrowserStack's local agent (see TESTING.md)
@@ -86,11 +87,7 @@ test-docker-browserstack-functional:
 
 # Run the tests in a container (see TESTING.md)
 test-docker:
-    # Unlike `up`, `run` doesn't create the ports that are specified by
-    # docker-compose.yml by default. These ports are needed for running the functional
-    # tests with the BrowserStack local agent, so we pass `--service-ports` to create
-    # them.
-    docker compose run --rm --service-ports {{ test_service }}
+    docker compose run --rm {{ test_service }}
 
 # Run the functional tests in a container (see TESTING.md)
 test-docker-functional:

--- a/justfile
+++ b/justfile
@@ -74,7 +74,7 @@ test-nonfunctional *args:
 
 # Start BrowserStack's local agent (see TESTING.md)
 browserstacklocal:
-    {{ justfile_directory() }}/bin/BrowserStackLocal --key "$BROWSERSTACK_ACCESS_KEY"
+    BrowserStackLocal --key "$BROWSERSTACK_ACCESS_KEY"
 
 # Run the functional tests using BrowserStack's local agent (see TESTING.md)
 test-browserstack-functional *args:

--- a/openprescribing/frontend/tests/functional/selenium_base.py
+++ b/openprescribing/frontend/tests/functional/selenium_base.py
@@ -33,7 +33,6 @@ def use_browserstack():
     "nonfunctional tests specified in TEST_SUITE environment variable",
 )
 class SeleniumTestCase(StaticLiveServerTestCase):
-    host = "0.0.0.0"
     display = None
 
     @classmethod


### PR DESCRIPTION
Here, we replace some binary you downloaded from the internet with some
image you downloaded from the internet. The image, and the resulting
containers, have several advantages over the binary:

1) You don't need to remember to download it, place it in a given
   directory, or start it. This is because Docker/Docker Compose does
   this for you.
2) You don't need to run the Django live server on 0.0.0.0 ("all local
   interfaces"). Instead, you can run the Django live server on
   localhost (the default). This is because the BrowserStackLocal
   container always shares a network namespace with the Django live
   server; either that of the host or that of the test container.
3) If you run functional tests locally *without* BrowserStackLocal, then
   the local Firefox web browser will request localhost rather than
   0.0.0.0 (see above). localhost is a valid client destination address;
   0.0.0.0 is not. Depending on your operating system, this may mean the
   tests run without error (whether or not they pass is another matter).
4) We don't need the browserstack/github-actions GitHub actions. This is
   because the local setup is very similar to the CI setup. The only
   difference is that the local setup calls docker compose run via a
   just recipe.