### PR TITLE
Add note about outside contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,9 @@
 # How to contribute
 
+> [!NOTE]
+> Thank you for your interest in OpenPrescribing.
+> Unfortunately, we're unable to accept outside contributions at present.
+
 Thank you for your interest in contributing! If you haven't already, drop us a line on mail@openprescribing.net. We want you working on things you're excited about.
 
 We use GitHub issues for suggestions and for bug tracking.


### PR DESCRIPTION
Noting where information is out of date is kinder than removing the information entirely.