### PR TITLE
Remove unused port mappings

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           GOOGLE_CLOUD_GITHUB_ACTIONS_PASSPHRASE: ${{ secrets.GOOGLE_CLOUD_GITHUB_ACTIONS_PASSPHRASE }}
       - name: Unit tests
-        run: docker compose run test && docker compose run --service-ports test-production
+        run: docker compose run test && docker compose run test-production
         env:
           TEST_SUITE: nonfunctional
             # We set these because the test service depends on the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     volumes:
       - postgis_data:/var/lib/postgresql/data/
     healthcheck:
-      test: [ "CMD-SHELL", "pg_isready; exit $(( $? != 0 ))" ]
+      test: ["CMD-SHELL", "pg_isready; exit $(( $? != 0 ))"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,9 +78,6 @@ services:
     environment:
       <<: *shared-environment
       DJANGO_SETTINGS_MODULE: openprescribing.settings.production
-    ports:
-      - "6080-6580:6080-6580"
-      - "6060:6060"
     volumes:
       - .:/code
     depends_on:


### PR DESCRIPTION
6080-6580 are used by the Django live server; 6060 is used by the mock
API server. As the test-production service runs the system check
framework, we need not map from the host to the guest.