### PR TITLE
Fix BrowserStackLocal in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,6 +60,7 @@ jobs:
           BROWSER: ${{ matrix.browser }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+          BROWSERSTACK_LOCAL_IDENTIFIER: ${{ github.run_id }}-${{ strategy.job-index }}
       - name: Notify slack failure
         if: failure()
         env:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,12 @@ x-browserstacklocal: &browserstacklocal
   # browserstacklocal and browserstacklocal-test to run simultaneously (they have
   # different network namespaces). However, only the container that started first would
   # bind the dashboard to localhost; the container that started second would error.
-  command: ["--key", "${BROWSERSTACK_ACCESS_KEY:-}", "--disable-dashboard"]
+  command:
+    - "--key"
+    - "${BROWSERSTACK_ACCESS_KEY:-}"
+    - "--local-identifier"
+    - "${BROWSERSTACK_LOCAL_IDENTIFIER:-}"
+    - "--disable-dashboard"
 
 services:
   postgis:


### PR DESCRIPTION
In b889efc, I replaced the BrowserStack-provided actions with a container. However, I neglected to set BROWSERSTACK_LOCAL_IDENTIFIER. The functional_tests job is run twice, in parallel: once for Edge and once for Firefox. Without different values of
BROWSERSTACK_LOCAL_IDENTIFIER, the second job will terminate the first job's access to the BrowserStack tunnel. So, it's a race and either Edge or Firefox must loose.