### PR TITLE
Make start-docker an ordinary recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -53,9 +53,6 @@ run *args:
 
 # Start the web app and database containers
 start-docker:
-    #!/usr/bin/env bash
-    set -euo pipefail
-
     # Unlike `up`, `run` doesn't create the ports that are specified by
     # docker-compose.yml by default. These ports are needed for connecting to the Django
     # development web server, so we pass `--service-ports` to create them.


### PR DESCRIPTION
Previously, start-docker was a [shebang recipe][] and, as such, was executed by saving its body to a file and running the file. Whilst it needed to be a shebang recipe in the past, it doesn't need to be one now, so we make it an ordinary recipe instead.

[shebang recipe]: https://just.systems/man/en/shebang-recipes.html