### PR TITLE
Invoke just recipes in CI

### DIFF
--- a/.github/actions/install-just/action.yml
+++ b/.github/actions/install-just/action.yml
@@ -1,0 +1,21 @@
+name: Install just
+description: Install the just command runner
+
+inputs:
+  version:
+    description: The version of just to install
+    required: false
+    default: "1.58.0"
+
+runs:
+  using: composite
+  steps:
+    - name: Install just
+      shell: bash
+      env:
+        JUST_VERSION: ${{ inputs.version }}
+      run: |
+        mkdir -p "$HOME/.local/bin"
+        curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh |
+          bash -s -- --tag "$JUST_VERSION" --to "$HOME/.local/bin"
+        echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,14 +52,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+      - name: Install just
+        uses: ./.github/actions/install-just
       - name: Retrieve Google Cloud credentials
         run: ./.github/scripts/decrypt_secret.sh
         env:
           GOOGLE_CLOUD_GITHUB_ACTIONS_PASSPHRASE: ${{ secrets.GOOGLE_CLOUD_GITHUB_ACTIONS_PASSPHRASE }}
       - name: Functional tests
-        run: docker compose run test
+        run: just test-docker-browserstack-functional
         env:
-          TEST_SUITE: functional
           BROWSER: ${{ matrix.browser }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,14 +17,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+      - name: Install just
+        uses: ./.github/actions/install-just
       - name: Retrieve Google Cloud credentials
         run: ./.github/scripts/decrypt_secret.sh
         env:
           GOOGLE_CLOUD_GITHUB_ACTIONS_PASSPHRASE: ${{ secrets.GOOGLE_CLOUD_GITHUB_ACTIONS_PASSPHRASE }}
       - name: Unit tests
-        run: docker compose run test
+        run: just test-docker-nonfunctional
         env:
-          TEST_SUITE: nonfunctional
           # We set this because the test service depends on the browserstacklocal-test
           # service for its network, and the latter won't start without it.
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
 
     strategy:
       matrix:
-        browser: [ "Edge:latest:Windows:10", "Firefox:latest:OS X:Catalina" ]
+        browser: ["Edge:latest:Windows:10", "Firefox:latest:OS X:Catalina"]
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -101,7 +101,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v7
         with:
-          python-version: '3.12'
+          python-version: "3.12"
       - name: "Linting"
         run: |
           pip install -r requirements.dev.txt
@@ -118,7 +118,7 @@ jobs:
 
   notify_slack:
     runs-on: ubuntu-latest
-    needs: [ unit_test , functional_tests , system_checks, linting ]
+    needs: [unit_test, functional_tests, system_checks, linting]
 
     steps:
       - name: Notify slack success

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -10,9 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - name: Install just
+        uses: ./.github/actions/install-just
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+      - name: Install uv
+        uses: astral-sh/setup-uv@v10
 
       - uses: actions/create-github-app-token@v3
         id: generate-token
@@ -26,11 +30,7 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
           automerge: false
           pr_title: "Update python dependencies"
-          update_command: |
-            pip install pip && \
-            pip install pip-tools && \
-            pip-compile --upgrade --no-header requirements.dev.in && \
-            pip-compile --upgrade --no-header requirements.in
+          update_command: just compile-requirements compile-dev-requirements
 
       - name: Notify slack of PR
         if: ${{ steps.update.outputs.pull-request-operation != 'none' }}

--- a/.github/workflows/update_dependencies.yml
+++ b/.github/workflows/update_dependencies.yml
@@ -3,41 +3,41 @@ name: Update python dependencies
 on:
   workflow_dispatch:
   schedule:
-    - cron:  "5 3 * * WED"
+    - cron: "5 3 * * WED"
 
 jobs:
   update-dependencies:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-python@v7
-      with:
-        python-version: '3.12'
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
 
-    - uses: actions/create-github-app-token@v3
-      id: generate-token
-      with:
-        app-id: ${{ vars.CREATE_PR_APP_ID }}
-        private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
+      - uses: actions/create-github-app-token@v3
+        id: generate-token
+        with:
+          app-id: ${{ vars.CREATE_PR_APP_ID }}
+          private-key: ${{ secrets.CREATE_PR_APP_PRIVATE_KEY }}
 
-    - uses: bennettoxford/update-dependencies-action@v1
-      id: update
-      with:
-        token: ${{ steps.generate-token.outputs.token }}
-        automerge: false
-        pr_title: "Update python dependencies"
-        update_command: |
-          pip install pip && \
-          pip install pip-tools && \
-          pip-compile --upgrade --no-header requirements.dev.in && \
-          pip-compile --upgrade --no-header requirements.in
+      - uses: bennettoxford/update-dependencies-action@v1
+        id: update
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          automerge: false
+          pr_title: "Update python dependencies"
+          update_command: |
+            pip install pip && \
+            pip install pip-tools && \
+            pip-compile --upgrade --no-header requirements.dev.in && \
+            pip-compile --upgrade --no-header requirements.in
 
-    - name: Notify slack of PR
-      if: ${{ steps.update.outputs.pull-request-operation != 'none' }}
-      uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d  # v4.0.0
-      with:
-        method: chat.postMessage
-        token: ${{ secrets.BENNETTBOT_SLACK_BOT_TOKEN }}
-        payload: |
-          channel: "C0A5WSK8L75"
-          text: "Update dependencies\n${{ steps.update.outputs.pull-request-url }}"
+      - name: Notify slack of PR
+        if: ${{ steps.update.outputs.pull-request-operation != 'none' }}
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.BENNETTBOT_SLACK_BOT_TOKEN }}
+          payload: |
+            channel: "C0A5WSK8L75"
+            text: "Update dependencies\n${{ steps.update.outputs.pull-request-url }}"


### PR DESCRIPTION
We now have several just recipes that invoke unit tests (i.e. non-functional tests), invoke functional tests, and update dependencies. These recipes capture how we expect to undertake these tasks, wherever we undertake them. I've been using them locally, and feel that now's the time to use them in CI.

You'll see from the history of this PR that I've moved several related changes to separate PRs (#5633 and #5631). I also fixed a regression (#5632), although the underlying issue continues to be vexing.