### PR TITLE
Add dependencies on devenv

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,7 +26,7 @@ clean:
     uv venv --clear
 
 # Run the code quality checks but don't modify any files
-check: _check-docker-compose
+check: devenv _check-docker-compose
     ./scripts/lint.sh
 
 _check-docker-compose:
@@ -36,14 +36,14 @@ _check-docker-compose:
 devenv:
     echo 'pip' | uv pip sync - requirements.txt requirements.dev.txt
 
-compile-requirements:
+compile-requirements: devenv
     uv run pip-compile --upgrade --no-header requirements.in
 
-compile-dev-requirements:
+compile-dev-requirements: devenv
     uv run pip-compile --upgrade --no-header requirements.dev.in
 
 # Run `manage.py`
-manage *args: db
+manage *args: db devenv
     uv run openprescribing/manage.py {{ args }}
 
 # Run `manage.py migrate`
@@ -62,7 +62,7 @@ start-docker:
     docker compose run --rm --service-ports {{ dev_service }}
 
 # Run the tests (see TESTING.md)
-test *args: db
+test *args: db devenv
     #!/usr/bin/env bash
     set -euo pipefail
 


### PR DESCRIPTION
Several recipes depend on devenv, but these dependencies were not explicit. Although it takes slightly longer to run a recipe that depends on devenv, it doesn't take *that* long (thanks, uv!). So, let's make these dependencies explicit so we don't, for example, have to remember whether our virtual environment is up to date before we call `just compile-requirements`.