### PR TITLE
Fix BrowserStackLocal in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,11 +25,9 @@ jobs:
         run: docker compose run test && docker compose run test-production
         env:
           TEST_SUITE: nonfunctional
-          # We set these because the test service depends on the
-          # browserstacklocal-test service for its network, and the latter won't start
-          # without them.
+          # We set this because the test service depends on the browserstacklocal-test
+          # service for its network, and the latter won't start without it.
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
-          BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       - name: Notify slack failure
         if: failure()
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,10 @@ jobs:
           # We set this because the test service depends on the browserstacklocal-test
           # service for its network, and the latter won't start without it.
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+          # We set this for a similar reason. Without a local identifier, starting the
+          # browserstacklocal-test service would terminate existing connections to
+          # BrowserStack.
+          BROWSERSTACK_LOCAL_IDENTIFIER: ${{ github.run_id }}-${{ strategy.job-index }}
       - name: Notify slack failure
         if: failure()
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,9 +25,9 @@ jobs:
         run: docker compose run test && docker compose run test-production
         env:
           TEST_SUITE: nonfunctional
-            # We set these because the test service depends on the
-            # browserstacklocal-test service for its network, and the latter won't start
-            # without them.
+          # We set these because the test service depends on the
+          # browserstacklocal-test service for its network, and the latter won't start
+          # without them.
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
       - name: Notify slack failure


### PR DESCRIPTION
Regrettably, this continues 4cdd4cc. It's clear that the unit_test job (GitHub Actions) depends on the test service (Docker Compose). It isn't clear that the test service depends on the browserstacklocal-test service. And it *really* isn't clear that starting the browserstacklocal-test service without setting a local identifier -- as we did here -- will terminate existing connections to the BrowserStack tunnel.

What does this mean? The jobs run in parallel; of these, one unit_test job and two functional_tests jobs establish connections to the BrowserStack tunnel. 4cdd4cc stopped the two functional_tests jobs terminating existing connections. However, it didn't stop the unit_test job from doing so. This does.

If you're scratching your head and thinking "Why did Iain change how we connect to the BrowserStack tunnel?", then see b889efc. We may decide that we don't want to run the functional tests against the browser on your machine, the browser on a Debian container, _and_ two browsers in the cloud. Nevertheless, we can at least make that decision knowing that the functional tests actually run against these browsers, without making ad hoc changes to the Django live server and downloading and setting up a BrowserStackLocal binary.