### PR TITLE
Run system checks in separate job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         env:
           GOOGLE_CLOUD_GITHUB_ACTIONS_PASSPHRASE: ${{ secrets.GOOGLE_CLOUD_GITHUB_ACTIONS_PASSPHRASE }}
       - name: Unit tests
-        run: docker compose run test && docker compose run test-production
+        run: docker compose run test
         env:
           TEST_SUITE: nonfunctional
           # We set this because the test service depends on the browserstacklocal-test
@@ -74,6 +74,24 @@ jobs:
           status: "FAILURE (functional test $BROWSER)"
           color: danger
 
+  system_checks:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Run system checks
+        run: docker compose run test-production
+      - name: Notify slack failure
+        if: failure()
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: tech-noise
+          status: "FAILURE (system_checks)"
+          color: danger
+
   linting:
     runs-on: ubuntu-latest
 
@@ -100,7 +118,7 @@ jobs:
 
   notify_slack:
     runs-on: ubuntu-latest
-    needs: [ unit_test , functional_tests , linting ]
+    needs: [ unit_test , functional_tests , system_checks, linting ]
 
     steps:
       - name: Notify slack success


### PR DESCRIPTION
Previously, we tacked system checks onto unit tests. Running system checks in a separate job will take more time, but there will be a clearer separation between system checks logs and unit tests logs.