### PR TITLE
Fix `BROWSERSTACK_LOCAL_IDENTIFIER`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           # We set this for a similar reason. Without a local identifier, starting the
           # browserstacklocal-test service would terminate existing connections to
           # BrowserStack.
-          BROWSERSTACK_LOCAL_IDENTIFIER: ${{ github.run_id }}-${{ strategy.job-index }}
+          BROWSERSTACK_LOCAL_IDENTIFIER: ${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}
       - name: Notify slack failure
         if: failure()
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
           BROWSER: ${{ matrix.browser }}
           BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
           BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
-          BROWSERSTACK_LOCAL_IDENTIFIER: ${{ github.run_id }}-${{ strategy.job-index }}
+          BROWSERSTACK_LOCAL_IDENTIFIER: ${{ github.run_id }}-${{ github.run_attempt }}-${{ github.job }}-${{ strategy.job-index }}
       - name: Notify slack failure
         if: failure()
         env:

--- a/justfile
+++ b/justfile
@@ -10,7 +10,6 @@ test_service := "test"
 # the DB_* just/environment variables come from the postgis service (see
 # docker-compose.yml).
 export BROWSERSTACK_BUILD_NAME := ""
-export BROWSERSTACK_LOCAL_IDENTIFIER := ""
 export BROWSERSTACK_PROJECT_NAME := ""
 export DB_NAME := "openprescribing-test"
 export DB_PASS := "pass"

--- a/justfile
+++ b/justfile
@@ -93,7 +93,7 @@ test-docker-browserstack-functional:
 
 # Run the tests in a container (see TESTING.md)
 test-docker:
-    docker compose run --rm {{ test_service }}
+    docker compose run --rm --quiet-pull {{ test_service }}
 
 # Run the functional tests in a container (see TESTING.md)
 test-docker-functional:


### PR DESCRIPTION
Several fixes to `BROWSERSTACK_LOCAL_IDENTIFIER` that ensure values are unique when jobs are run both individually and collectively in CI, and values aren't clobbered.