### PR TITLE
Flag BNF codes with no prescribing as `is_current=False`

### DIFF
--- a/openprescribing/pipeline/management/commands/refresh_bnf_class_currency.py
+++ b/openprescribing/pipeline/management/commands/refresh_bnf_class_currency.py
@@ -31,4 +31,4 @@ class Command(BaseCommand):
                     prefix = getattr(obj, field_name)
                     if prefix in all_bnf_prefixes:
                         obj.is_current = True
-                        obj.save()
+                        obj.save(update_fields=["is_current"])

--- a/openprescribing/pipeline/management/commands/refresh_bnf_class_currency.py
+++ b/openprescribing/pipeline/management/commands/refresh_bnf_class_currency.py
@@ -27,8 +27,7 @@ class Command(BaseCommand):
         ]
         with transaction.atomic():
             for model, field_name in classes:
-                for obj in model.objects.filter(is_current=False):
+                for obj in model.objects.filter():
                     prefix = getattr(obj, field_name)
-                    if prefix in all_bnf_prefixes:
-                        obj.is_current = True
-                        obj.save(update_fields=["is_current"])
+                    obj.is_current = prefix in all_bnf_prefixes
+                    obj.save(update_fields=["is_current"])

--- a/openprescribing/pipeline/management/commands/refresh_bnf_class_currency.py
+++ b/openprescribing/pipeline/management/commands/refresh_bnf_class_currency.py
@@ -13,6 +13,11 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         all_bnf_codes = get_all_bnf_codes()
+        all_bnf_prefixes = {
+            bnf_code[:i]
+            for bnf_code in all_bnf_codes
+            for i in range(1, len(bnf_code) + 1)
+        }
 
         classes = [
             (Section, "bnf_id"),
@@ -24,6 +29,6 @@ class Command(BaseCommand):
             for model, field_name in classes:
                 for obj in model.objects.filter(is_current=False):
                     prefix = getattr(obj, field_name)
-                    if any(bnf_code.startswith(prefix) for bnf_code in all_bnf_codes):
+                    if prefix in all_bnf_prefixes:
                         obj.is_current = True
                         obj.save()

--- a/openprescribing/pipeline/tests/test_refresh_bnf_class_currency.py
+++ b/openprescribing/pipeline/tests/test_refresh_bnf_class_currency.py
@@ -9,25 +9,25 @@ from matrixstore.tests.data_factory import DataFactory
 
 class TestCommand(TestCase):
     def test_refresh_bnf_class_currency(self):
-        Section.objects.create(bnf_id="01", bnf_chapter=1, is_current=True)
-        Section.objects.create(bnf_id="02", bnf_chapter=2, is_current=True)
-        Section.objects.create(bnf_id="03", bnf_chapter=3, is_current=False)
-        Section.objects.create(bnf_id="04", bnf_chapter=4, is_current=False)
+        Section.objects.create(bnf_id="01", bnf_chapter=1)
+        Section.objects.create(bnf_id="02", bnf_chapter=2)
+        Section.objects.create(bnf_id="03", bnf_chapter=3)
+        Section.objects.create(bnf_id="04", bnf_chapter=4)
 
-        Chemical.objects.create(bnf_code="010101001", is_current=True)
-        Chemical.objects.create(bnf_code="020101001", is_current=True)
-        Chemical.objects.create(bnf_code="030101001", is_current=False)
-        Chemical.objects.create(bnf_code="040101001", is_current=False)
+        Chemical.objects.create(bnf_code="010101001")
+        Chemical.objects.create(bnf_code="020101001")
+        Chemical.objects.create(bnf_code="030101001")
+        Chemical.objects.create(bnf_code="040101001")
 
-        Product.objects.create(bnf_code="010101001AA", is_current=True)
-        Product.objects.create(bnf_code="020101001AA", is_current=True)
-        Product.objects.create(bnf_code="030101001AA", is_current=False)
-        Product.objects.create(bnf_code="040101001AA", is_current=False)
+        Product.objects.create(bnf_code="010101001AA")
+        Product.objects.create(bnf_code="020101001AA")
+        Product.objects.create(bnf_code="030101001AA")
+        Product.objects.create(bnf_code="040101001AA")
 
-        Presentation.objects.create(bnf_code="010101001AAAAAA", is_current=True)
-        Presentation.objects.create(bnf_code="020101001AAAAAA", is_current=True)
-        Presentation.objects.create(bnf_code="030101001AAAAAA", is_current=False)
-        Presentation.objects.create(bnf_code="040101001AAAAAA", is_current=False)
+        Presentation.objects.create(bnf_code="010101001AAAAAA")
+        Presentation.objects.create(bnf_code="020101001AAAAAA")
+        Presentation.objects.create(bnf_code="030101001AAAAAA")
+        Presentation.objects.create(bnf_code="040101001AAAAAA")
 
         factory = DataFactory()
         factory.create_prescribing_for_bnf_codes(["010101001AAAAAA", "030101001AAAAAA"])

--- a/openprescribing/pipeline/tests/test_refresh_bnf_class_currency.py
+++ b/openprescribing/pipeline/tests/test_refresh_bnf_class_currency.py
@@ -36,21 +36,25 @@ class TestCommand(TestCase):
             call_command("refresh_bnf_class_currency")
 
         self.assertTrue(Section.objects.get(bnf_id="01").is_current)
-        self.assertTrue(Section.objects.get(bnf_id="02").is_current)
+        self.assertFalse(Section.objects.get(bnf_id="02").is_current)
         self.assertTrue(Section.objects.get(bnf_id="03").is_current)
         self.assertFalse(Section.objects.get(bnf_id="04").is_current)
 
         self.assertTrue(Chemical.objects.get(bnf_code="010101001").is_current)
-        self.assertTrue(Chemical.objects.get(bnf_code="020101001").is_current)
+        self.assertFalse(Chemical.objects.get(bnf_code="020101001").is_current)
         self.assertTrue(Chemical.objects.get(bnf_code="030101001").is_current)
         self.assertFalse(Chemical.objects.get(bnf_code="040101001").is_current)
 
         self.assertTrue(Product.objects.get(bnf_code="010101001AA").is_current)
-        self.assertTrue(Product.objects.get(bnf_code="020101001AA").is_current)
+        self.assertFalse(Product.objects.get(bnf_code="020101001AA").is_current)
         self.assertTrue(Product.objects.get(bnf_code="030101001AA").is_current)
         self.assertFalse(Product.objects.get(bnf_code="040101001AA").is_current)
 
         self.assertTrue(Presentation.objects.get(bnf_code="010101001AAAAAA").is_current)
-        self.assertTrue(Presentation.objects.get(bnf_code="020101001AAAAAA").is_current)
+        self.assertFalse(
+            Presentation.objects.get(bnf_code="020101001AAAAAA").is_current
+        )
         self.assertTrue(Presentation.objects.get(bnf_code="030101001AAAAAA").is_current)
-        self.assertFalse(Presentation.objects.get(bnf_code="040101001AAAAAA").is_current)
+        self.assertFalse(
+            Presentation.objects.get(bnf_code="040101001AAAAAA").is_current
+        )

--- a/openprescribing/pipeline/tests/test_refresh_bnf_class_currency.py
+++ b/openprescribing/pipeline/tests/test_refresh_bnf_class_currency.py
@@ -35,16 +35,22 @@ class TestCommand(TestCase):
         with patched_global_matrixstore_from_data_factory(factory):
             call_command("refresh_bnf_class_currency")
 
-        self.assertEqual(Section.objects.filter(is_current=True).count(), 3)
-        self.assertEqual(Section.objects.get(is_current=False).bnf_id, "04")
+        self.assertTrue(Section.objects.get(bnf_id="01").is_current)
+        self.assertTrue(Section.objects.get(bnf_id="02").is_current)
+        self.assertTrue(Section.objects.get(bnf_id="03").is_current)
+        self.assertFalse(Section.objects.get(bnf_id="04").is_current)
 
-        self.assertEqual(Chemical.objects.filter(is_current=True).count(), 3)
-        self.assertEqual(Chemical.objects.get(is_current=False).bnf_code, "040101001")
+        self.assertTrue(Chemical.objects.get(bnf_code="010101001").is_current)
+        self.assertTrue(Chemical.objects.get(bnf_code="020101001").is_current)
+        self.assertTrue(Chemical.objects.get(bnf_code="030101001").is_current)
+        self.assertFalse(Chemical.objects.get(bnf_code="040101001").is_current)
 
-        self.assertEqual(Product.objects.filter(is_current=True).count(), 3)
-        self.assertEqual(Product.objects.get(is_current=False).bnf_code, "040101001AA")
+        self.assertTrue(Product.objects.get(bnf_code="010101001AA").is_current)
+        self.assertTrue(Product.objects.get(bnf_code="020101001AA").is_current)
+        self.assertTrue(Product.objects.get(bnf_code="030101001AA").is_current)
+        self.assertFalse(Product.objects.get(bnf_code="040101001AA").is_current)
 
-        self.assertEqual(Presentation.objects.filter(is_current=True).count(), 3)
-        self.assertEqual(
-            Presentation.objects.get(is_current=False).bnf_code, "040101001AAAAAA"
-        )
+        self.assertTrue(Presentation.objects.get(bnf_code="010101001AAAAAA").is_current)
+        self.assertTrue(Presentation.objects.get(bnf_code="020101001AAAAAA").is_current)
+        self.assertTrue(Presentation.objects.get(bnf_code="030101001AAAAAA").is_current)
+        self.assertFalse(Presentation.objects.get(bnf_code="040101001AAAAAA").is_current)


### PR DESCRIPTION
Previously, we would automatically flag codes as `is_current=True` when prescribing appeared for them but we wouldn't do the reverse.

I've looked at the PR which introduced the original behaviour and the associated issues, but it's not clear why it worked this way:
 * https://github.com/bennettoxford/openprescribing/pull/380

This change was prompted by the discussion below, in which @richiecroker agrees that the new behaviour is what we want:
https://bennettoxford.slack.com/archives/C051A4P27GE/p1787666287464959

This command will run automatically as part of the data import process, but if we want the change to take effect without waiting for that then we can run it manually after deployment:
```
./manage.py refresh_bnf_class_currency
```

