### PR TITLE
Add OpenTelemetry/Honeycomb

### DIFF
--- a/bin/gunicorn_start
+++ b/bin/gunicorn_start
@@ -62,6 +62,7 @@ if [[ -z "$PORT" && -z "$LISTEN_FDS" ]]; then
 fi
 
 cmd="gunicorn openprescribing.wsgi:application \
+  --config openprescribing/openprescribing/settings/gunicorn.conf.py
   --name $NAME \
   --workers $GUNICORN_NUM_WORKERS \
   --timeout $GUNICORN_TIMEOUT \

--- a/environment-sample
+++ b/environment-sample
@@ -42,6 +42,9 @@ SLACK_TECHNOISE_POST_KEY=slack_technoise_post_key
 SLACK_OP_POST_KEY=slack_op_post_key
 CF_API_KEY=cf_api_key
 
+OTEL_EXPORTER_OTLP_ENDPOINT=https://api.honeycomb.io
+OTEL_EXPORTER_OTLP_HEADERS='x-honeycomb-team=<your-api-key>'
+
 # The path to a file containing your credentials for accessing Google Cloud
 # Platform services (eg BigQuery, Cloud Storage).
 # GOOGLE_APPLICATION_CREDENTIALS=

--- a/justfile
+++ b/justfile
@@ -54,6 +54,17 @@ migrate *args:
 run *args:
     {{ just_executable() }} manage runserver {{ args }}
 
+# Run with Gunicorn for development and testing
+[env("DJANGO_SETTINGS_MODULE", "openprescribing.settings.production")]
+[env("GUNICORN_LOG_LEVEL", "info")]
+[env("GUNICORN_NUM_WORKERS", "1")]
+[env("GUNICORN_TIMEOUT", "30")]
+[env("OTEL_EXPORTER_OTLP_ENDPOINT", "https://api.honeycomb.io")]
+[env("PORT", "8000")]
+[env("VIRTUALENV_PATH", ".venv")]
+run-gunicorn: db
+    bin/gunicorn_start
+
 # Start the web app and database containers
 start-docker:
     # Unlike `up`, `run` doesn't create the ports that are specified by

--- a/openprescribing/openprescribing/settings/gunicorn.conf.py
+++ b/openprescribing/openprescribing/settings/gunicorn.conf.py
@@ -1,0 +1,19 @@
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+
+# BatchSpanProcessor doesn't work well with Gunicorn, but we can work around its
+# limitations with a post-fork hook. For more information, see:
+# https://opentelemetry-python.readthedocs.io/en/latest/examples/fork-process-model/README.html
+def post_fork(server, worker):
+    server.log.info("Worker spawned (pid: %s)", worker.pid)
+    resource = Resource.create(attributes={"service.name": "openprescribing"})
+    trace.set_tracer_provider(TracerProvider(resource=resource))
+    span_processor = BatchSpanProcessor(OTLPSpanExporter())
+    trace.get_tracer_provider().add_span_processor(span_processor)
+    from opentelemetry.instrumentation.auto_instrumentation import (  # noqa: F401
+        sitecustomize,
+    )

--- a/requirements.in
+++ b/requirements.in
@@ -72,3 +72,8 @@ seaborn
 lxml
 numpy
 jinja2
+
+# OpenTelemetry
+opentelemetry-sdk
+opentelemetry-instrumentation-django
+opentelemetry-exporter-otlp-proto-http

--- a/requirements.txt
+++ b/requirements.txt
@@ -147,6 +147,7 @@ googleapis-common-protos==1.75.3
     # via
     #   google-api-core
     #   grpcio-status
+    #   opentelemetry-exporter-otlp-proto-http
 graphviz==0.21
     # via -r requirements.in
 grpcio==1.83.1
@@ -215,7 +216,44 @@ oauthlib==3.3.1
 openpyxl==3.1.5
     # via -r requirements.in
 opentelemetry-api==1.44.0
-    # via google-api-core
+    # via
+    #   google-api-core
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
+opentelemetry-exporter-otlp-proto-common==1.44.0
+    # via opentelemetry-exporter-otlp-proto-http
+opentelemetry-exporter-otlp-proto-http==1.44.0
+    # via -r requirements.in
+opentelemetry-instrumentation==0.65b0
+    # via
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-wsgi
+opentelemetry-instrumentation-django==0.65b0
+    # via -r requirements.in
+opentelemetry-instrumentation-wsgi==0.65b0
+    # via opentelemetry-instrumentation-django
+opentelemetry-proto==1.44.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.44.0
+    # via
+    #   -r requirements.in
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-semantic-conventions==0.65b0
+    # via
+    #   opentelemetry-instrumentation
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-wsgi
+    #   opentelemetry-sdk
+opentelemetry-util-http==0.65b0
+    # via
+    #   opentelemetry-instrumentation-django
+    #   opentelemetry-instrumentation-wsgi
 outcome==1.3.0.post0
     # via
     #   trio
@@ -226,6 +264,7 @@ packaging==26.3
     #   db-dtypes
     #   google-cloud-bigquery
     #   matplotlib
+    #   opentelemetry-instrumentation
     #   pandas-gbq
     #   wheel
 pandas==2.3.3
@@ -254,6 +293,7 @@ protobuf==7.36.1
     #   google-cloud-bigquery-storage
     #   googleapis-common-protos
     #   grpcio-status
+    #   opentelemetry-proto
     #   proto-plus
 psutil==7.2.2
     # via pandas-gbq
@@ -310,6 +350,7 @@ requests[security]==2.34.2
     #   google-api-core
     #   google-cloud-bigquery
     #   google-cloud-storage
+    #   opentelemetry-exporter-otlp-proto-http
     #   premailer
     #   requests-futures
     #   requests-oauthlib
@@ -352,6 +393,9 @@ typing-extensions==4.16.0
     #   beautifulsoup4
     #   grpcio
     #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-http
+    #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   selenium
 tzdata==2026.3
     # via pandas
@@ -372,6 +416,8 @@ wheel==0.48.0
     # via pip-tools
 when-changed==0.3.0
     # via -r requirements.in
+wrapt==2.4.0
+    # via opentelemetry-instrumentation
 wsproto==1.3.2
     # via trio-websocket
 xlrd==2.0.2


### PR DESCRIPTION
This adds everything we need to send OpenTelemetry data to Honeycomb. We don't, I believe, test Gunicorn, so I've included a just recipe that runs the site using default values for expected environment variables; if you place a Honeycomb ingest API key for the testing environment in .env and run `just run-gunicorn`, then you should see OpenTelemetry data for the openprescribing service appear in Honeycomb's testing environment.